### PR TITLE
Update setup to reflect README.rst

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,5 @@ setup(
     # The license can be anything you like
     license          = open('LICENSE.txt').read(),
     description      = 'Matplotlib wrapper for making clear, concise, publication-quality graphics quickly and easily.',
-    long_description = open('README.md').read(),
+    long_description = open('README.rst').read(),
 )


### PR DESCRIPTION
Massive fix. Update the `setup.py` profile to the proper README extension. Currently pip install doesn't work because of this bug.