### PR TITLE
Add AAAS journals to subplot command

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
+=================
 Changelog History
 =================
 
 ProPlot v1.0.0
---------------
+==============
 First official release. Coming soon! Future changes and releases will be documented.
+
+Internals/Minor Fixes
+---------------------
+- Add AAAS journal specifications to ``journal`` keyword for ``proplot.subplots()``, fix bug breaking on certain journals, add testing. (:pr:`30`) `Riley X. Brady`_.
+
+
+.. _`Luke Davis`: https://github.com/lukelbd
+.. _`Riley X. Brady`: https://github.com/bradyrx

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,6 +61,11 @@ extensions = [
     # 'matplotlib.sphinxext.plot_directive', # see: https://matplotlib.org/sampledoc/extensions.html
     ]
 
+extlinks = {
+    'issue': ('https://github.com/lukelbd/proplot/issues/%s', 'GH#'),
+    'pr': ('https://github.com/lukelbd/proplot/pull/%s', 'GH#'),
+}
+
 # Do not run doctest tests, these are just to show syntax and expected
 # output may be graphical
 doctest_test_doctest_blocks = ''

--- a/proplot/subplots.py
+++ b/proplot/subplots.py
@@ -1485,6 +1485,8 @@ def _journals(journal):
         'agu2': ('190mm', '115mm'),
         'agu3': ('95mm',  '230mm'),
         'agu4': ('190mm', '230mm'),
+        'aaas1': '5.5cm', # AAAS (e.g., Science) 1 column
+        'aaas2': '12cm', # AAAS 2 column
         }
     value = table.get(journal, None)
     if value is None:
@@ -1494,7 +1496,7 @@ def _journals(journal):
     width, height = None, None
     try:
         width, height = value
-    except TypeError:
+    except ValueError:
         width = value
     return width, height
 

--- a/proplot/subplots.py
+++ b/proplot/subplots.py
@@ -63,6 +63,24 @@ _side_translate = {
     't':'top',
     }
 
+# Dimensions of figures for common journals
+JOURNAL_SPECS = {
+    'pnas1': '8.7cm', # if 1 number specified, this is a tuple
+    'pnas2': '11.4cm',
+    'pnas3': '17.8cm',
+    'ams1': 3.2, # spec is in inches
+    'ams2': 4.5,
+    'ams3': 5.5,
+    'ams4': 6.5,
+    'agu1': ('95mm',  '115mm'),
+    'agu2': ('190mm', '115mm'),
+    'agu3': ('95mm',  '230mm'),
+    'agu4': ('190mm', '230mm'),
+    'aaas1': '5.5cm', # AAAS (e.g., Science) 1 column
+    'aaas2': '12cm', # AAAS 2 column
+    }
+
+
 #-----------------------------------------------------------------------------#
 # Miscellaneous stuff
 #-----------------------------------------------------------------------------#
@@ -1473,30 +1491,16 @@ class Figure(mfigure.Figure):
 #-----------------------------------------------------------------------------#
 def _journals(journal):
     """Journal sizes for figures."""
-    table = {
-        'pnas1': '8.7cm', # if 1 number specified, this is a tuple
-        'pnas2': '11.4cm',
-        'pnas3': '17.8cm',
-        'ams1': 3.2, # spec is in inches
-        'ams2': 4.5,
-        'ams3': 5.5,
-        'ams4': 6.5,
-        'agu1': ('95mm',  '115mm'),
-        'agu2': ('190mm', '115mm'),
-        'agu3': ('95mm',  '230mm'),
-        'agu4': ('190mm', '230mm'),
-        'aaas1': '5.5cm', # AAAS (e.g., Science) 1 column
-        'aaas2': '12cm', # AAAS 2 column
-        }
-    value = table.get(journal, None)
+    # Get dimensions for figure from common journals.
+    value = JOURNAL_SPECS.get(journal, None)
     if value is None:
         raise ValueError(f'Unknown journal figure size specifier {journal!r}. ' +
-                          'Current options are: ' + ', '.join(table.keys()))
+                          'Current options are: ' + ', '.join(JOURNAL_SPECS.keys()))
     # Return width, and optionally also the height
     width, height = None, None
     try:
         width, height = value
-    except ValueError:
+    except (TypeError, ValueError):
         width = value
     return width, height
 

--- a/proplot/tests/test_journals.py
+++ b/proplot/tests/test_journals.py
@@ -1,0 +1,11 @@
+import pytest
+
+import proplot as plot
+from proplot.subplots import JOURNAL_SPECS
+
+
+# Loop through all available journals.
+@pytest.mark.parametrize('journal', JOURNAL_SPECS.keys())
+def test_journal_subplots(journal):
+    """Tests that subplots can be generated with journal specifications."""
+    f, axs = plot.subplots(journal=journal)


### PR DESCRIPTION
@lukelbd, this PR adds the AAAS journal specs to the `proplot.subplots()` command. It also has a few minor fixes:
* Move the journal specs table to the header and change name to `JOURNAL_SPECS` following PEP (https://www.python.org/dev/peps/pep-0008/#constants).
* Fix try/except clause in `subplots()` that was causing certain journal specs to break.
* Add `pytest` for all journal specs as a template for future testing.
* Update changelog and add capability in docs to link from changelog to PR/issue threads.

This is a great simple example of pytest's power. I created the test then ran pytest and found consistent errors in certain subsets of the dictionary (`TypeError` vs. `ValueError`). Once you get pytest implemented into Travis CI, this will run automatically on PRs and then you have no risk of importing broken code. At least broken journal spec code for now.