### PR TITLE
Add panels as parasite child axes instead of embedding them in the gridspec

### DIFF
--- a/proplot/subplots.py
+++ b/proplot/subplots.py
@@ -295,24 +295,20 @@ class axes_grid(list):
         # Mixed
         raise AttributeError(f'Found mixed types for attribute {attr!r}.')
 
-    # TODO: No more putting panels, legends, colorbars on the SubplotSpec.
-    # Put them in the margin, increase default space, and lock them to
-    # subplot bounds with locators, borrowing from axes_grid1 toolkit
-    # TODO: Consider adding Github issue, would be major API change.
-    # def colorbar(self, loc=None):
-    #     """Draws a colorbar that spans axes in the selected range."""
-    #     for ax in self:
-    #         pass
-    #
-    # def legend(self, loc=None):
-    #     """Draws a legend that spans axes in the selected range."""
-    #     for ax in self:
-    #         pass
-    #
-    # def text(self, loc=None):
-    #     """Draws text that spans axes in the selected range."""
-    #     for ax in self:
-    #         pass
+    def colorbar(self, loc=None):
+        """Draws a colorbar that spans axes in the selected range."""
+        for ax in self:
+            pass
+
+    def legend(self, loc=None):
+        """Draws a legend that spans axes in the selected range."""
+        for ax in self:
+            pass
+
+    def text(self, loc=None):
+        """Draws text that spans axes in the selected range."""
+        for ax in self:
+            pass
 
 #-----------------------------------------------------------------------------#
 # Gridspec classes


### PR DESCRIPTION
This is a major refactor I am just **considering** for now. It might make more sense to add axes panels, legends, and colorbars as **parasites** of the original subplot(s) instead of modifying the underlying subplotspec. 

There is some existing similar code for this in the `axes_grid1` toolkit. I could borrow this code so that panel, colorbar, and legend long-axis coordinates are automatically updated when subplot positions change.

There are several advantages here.

*  Panels in the same row or column no longer have to be the same width, which can be a problem when you have legends + colorbars alongisde each other.
* It would be relatively straightforward to implement an `axes_grid` legend, colorbar, and text methods that draw legends and colorbars or labels along the sides of **arbitrary contiguous** axes, instead of just along the figure edge.
* We would no longer have to modify the underlying gridspec when inserting panels. Could delete the cumbersome `Figure._insert_rows_columns` function.
* Legends no longer have to belong to an empty, dummy axes -- we can just lock the legend position.
* Colorbars no longer have to belong to empty, dummy axes to extend them along <100% of the axes -- we just adjust the parent-relative long axis coordinates. This also eliminates all references to GridSpecFromSubplotSpec, which proplot's GridSpec tries to make obsolete.
* We can now implement `rowlabels` and `collabels` with the same API, allow "stacking" arbitrary outer text objects just like colorbars/legends/panels.

The difficulty is that I would have to figure out how to specify axes bounds so that their long axis is *locked* to another axes (probably similar to the `inset_axes` locator) and their short axes has *locked* physical width (i.e. is not in physical units). Also, currently, the `tight_layout` algorithm works to separate panels and subplots alike by just inspecting axes in adjacent rows/columns of the gridspec. With this PR, an additional step in the algorithm that separates "stacked" objects will have to be written.

This should probably be a v2.0 feature. Really not sure how many people would find it useful/how often someone will run into issues with requiring different panel widths on the same GridSpec row/column. But, I'm leaving this open to discussion.