### PR TITLE
Make sure that long_name has priority over standard_name

### DIFF
--- a/proplot/wrappers.py
+++ b/proplot/wrappers.py
@@ -153,7 +153,7 @@ def _auto_label(data, axis=None, units=True):
         if axis is not None and data.ndim > axis:
             data = data.coords[data.dims[axis]]
         label = getattr(data, 'name', '') or ''
-        for key in ('long_name', 'standard_name'):
+        for key in ('standard_name', 'long_name'):
             label = data.attrs.get(key, label)
         if units:
             units = data.attrs.get('units', '')


### PR DESCRIPTION
If the long_name attribute of an xarray is available, it must be used for labels instead of the standard_name.