### PR TITLE
Dedicated classes for inset colorbars, centered-row legends, ...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,10 @@ dist
 docs/api
 docs/_build
 
+# Folder of notebooks for testing and bugfixing
+local
+
 # Notebook stuff
-**/tests/*.ipynb
 .ipynb_checkpoints
 
 # Python extras


### PR DESCRIPTION
Centered-row legends and inset colorbars are currently implemented on the Figure and Axes *methods* with [`colorbar_wrapper`](https://proplot.readthedocs.io/en/latest/api/proplot.wrappers.colorbar_wrapper.html)  and [`legend_wrapper`](https://proplot.readthedocs.io/en/latest/api/proplot.wrappers.legend_wrapper.html). But this means background patch tasks that *would* be carried out by the `Colorbar` and `Legend` classes at draw-time have to be done during call-time.

* For legend, this may cause esoteric display errors if the `renderer` being used to position the "centered-legend" box changes between `legend()` call-time and draw-time.
* For colorbar, we worked around this by severely restricting the bounding box options and estimating the necessary space from font sizes. But it would be *much* better if the box shape was adjusted dynamically to emcompass colorbar contents.

Current commit is broken but just wanted to set this up.

Also, while starting this PR I learned about some intriguing matplotlib classes in the [offsetbox module](https://matplotlib.org/3.1.1/api/offsetbox_api.html) used to automatically position legend labels / text. The [`HPacker`](https://matplotlib.org/3.1.1/api/offsetbox_api.html?highlight=pack#matplotlib.offsetbox.HPacker) and [`VPacker`](https://matplotlib.org/3.1.1/api/offsetbox_api.html#matplotlib.offsetbox.VPacker) classes might be used to implement #46. [Anchored artists](https://matplotlib.org/3.1.1/gallery/misc/anchored_artists.html) might also be useful for both PRs.