### PR TITLE
Axis scale improvements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,6 @@ repos:
     - id: double-quote-string-fixer
     - id: check-docstring-first
     - id: check-merge-conflict
-    - id: check-yaml
     - id: end-of-file-fixer
     - id: trailing-whitespace
     - id: flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,6 @@ repos:
     - id: check-docstring-first
     - id: check-merge-conflict
     - id: check-yaml
-    - id: debug-statements
     - id: end-of-file-fixer
     - id: trailing-whitespace
     - id: flake8

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -66,6 +66,7 @@ ProPlot v0.4.0 (2020-##-##)
 
 - Remove redundant `~proplot.rctools.use_fonts`, use ``rcParams['sans-serif']``
   precedence instead (:pr:`95`).
+- `~proplot.axes.Axes.dualx` and `~proplot.axes.Axes.dualx` no longer accept "scale-spec" arguments, must be a function, two functions, or an axis scale instance (:pr:`96`).
 
 .. rubric:: Features
 
@@ -76,6 +77,7 @@ ProPlot v0.4.0 (2020-##-##)
 .. rubric:: Bug fixes
 
 - Fix `~proplot.rctools.rc_configurator.context` bug (:issue:`80` and :pr:`91`).
+- Fix issues with `~proplot.axes.Axes.dualx` and `~proplot.axes.Axes.dualy` with non-linear parent scales (:pr:`96`).
 - Ignore TTC fonts because they cannot be saved in EPS/PDF figures (:issue:`94` and :pr:`95`).
 - Do not try to use Helvetica Neue because "thin" font style is read as regular (:issue:`94` and :pr:`95`).
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,7 @@ ProPlot v1.0.0 (2020-##-##)
 This will be published when some major refactoring tasks are completed.
 See :pr:`45`, :pr:`46`, and :pr:`50`.
 
-ProPlot v0.4.0 (2020-##-##)
+ProPlot v0.5.0 (2020-##-##)
 ===========================
 .. rubric:: Deprecated
 
@@ -60,17 +60,29 @@ ProPlot v0.4.0 (2020-##-##)
   with a default ``.proplotrc`` file, change the auto-generated user ``.proplotrc``
   (:pr:`50`).
 
-ProPlot v0.3.2 (2020-##-##)
+ProPlot v0.4.0 (2020-##-##)
 ===========================
+.. rubric:: Deprecated
+
+- Remove redundant `~proplot.rctools.use_fonts`, use ``rcParams['sans-serif']``
+  precedence instead (:pr:`95`).
+
+.. rubric:: Features
+
+- Add Fira Math as DejaVu Sans-alternative (:pr:`95`). Has complete set of math characters.
+- Add TeX Gyre Heros as Helvetica-alternative (:pr:`95`). This is the new open-source default font.
+- Add `~proplot.subplots.Figure` ``fallback_to_cm`` kwarg. This is used by `~proplot.styletools.show_fonts` to show dummy glyphs to clearly illustrate when fonts are missing characters, but preserve graceful fallback for end user.
+
 .. rubric:: Bug fixes
 
 - Fix `~proplot.rctools.rc_configurator.context` bug (:issue:`80` and :pr:`91`).
-- Improvements to fonts API (:pr:`93`).
+- Ignore TTC fonts because they cannot be saved in EPS/PDF figures (:issue:`94` and :pr:`95`).
+- Do not try to use Helvetica Neue because "thin" font style is read as regular (:issue:`94` and :pr:`95`).
 
 .. rubric:: Documentation
 
 - Imperative mood for docstring summaries (:pr:`92`).
-- Fix `~proplot.show_cycles` bug (:pr:`90`) and show cycles using colorbars rather than lines.
+- Fix `~proplot.styletools.show_cycles` bug (:pr:`90`) and show cycles using colorbars rather than lines.
 
 ProPlot v0.3.1 (2019-12-16)
 ===========================

--- a/docs/axis.ipynb
+++ b/docs/axis.ipynb
@@ -213,8 +213,15 @@
     "raw_mimetype": "text/restructuredtext"
    },
    "source": [
-    "The axis scale can be changed with `~proplot.axes.Axes.format` (keyword args `xscale` and `yscale`). You can now configure the ``'log'`` and ``'symlog'`` axis scales with the more sensible `base`, `linthresh`, `linscale`, and `subs`\n",
-    "keyword args, rather than ``basex``, ``basey``, etc. Also, ProPlot's `~proplot.axistools.AutoFormatter` formatter is used for all axis scales by default; this can be changed e.g. by passing ``yformatter='log'`` to `~proplot.axes.XYAxes.format`. See `~proplot.axistools.Scale`, `~proplot.axistools.LogScale` and `~proplot.axistools.SymmetricalLogScale` for details."
+    "The axis scale can be changed with `~proplot.axes.Axes.format` (keyword args `xscale` and `yscale`). ProPlot makes some changes to the axis scale API:\n",
+    "\n",
+    "* You can now pass scale classes to `~matplotlib.axes.Axes.set_xscale`, `~matplotlib.axes.Axes.set_yscale`, and `~proplot.axes.Axes.format` directly, rather than just strings.\n",
+    "* ProPlot `~proplot.axistools.Scale` classes can be instantiated *without* an `~matplotlib.axis.Axis` instance. This is required in matplotlib for backward compatibility reasons.\n",
+    "* The ``'log'`` and ``'symlog'`` axis scales can be configured with the more sensible `base`, `linthresh`, `linscale`, and `subs` keyword args, rather than `basex`, `basey`, etc. \n",
+    "* The `~proplot.axistools.AutoFormatter` formatter is used for all axis scales by default. This can be changed e.g. by passing ``yformatter='log'`` to `~proplot.axes.XYAxes.format`.\n",
+    "* The default minor tick locations for the ``'log'`` and ``'symlog'`` axis scales are now both ``np.arange(1, 10)``. The default \"threshold\" for the ``'symlog'`` axis scale is now ``1``.\n",
+    "\n",
+    "See `~proplot.axistools.Scale` for details.\n"
    ]
   },
   {
@@ -230,16 +237,16 @@
     "plot.rc.update({'linewidth': 1, 'ticklabelweight': 'bold',\n",
     "                'axeslabelweight': 'bold'})\n",
     "f, axs = plot.subplots(ncols=2, nrows=2, axwidth=1.8, share=0)\n",
-    "axs.format(suptitle='Axis scales demo')\n",
+    "axs.format(suptitle='Axis scales demo', ytickminor=True)\n",
     "# Linear and log scales\n",
     "axs[0].format(yscale='linear', ylabel='linear scale')\n",
-    "axs[1].format(ylim=(1e-3, 1e3), yscale='log',\n",
-    "              yscale_kw={'subs': np.arange(1, 10)}, ylabel='log scale')\n",
+    "axs[1].format(ylim=(1e-3, 1e3), yscale='log', ylabel='log scale')\n",
     "axs[:2].plot(np.linspace(0, 1, N), np.linspace(0, 1000, N), lw=lw)\n",
-    "# Symlog and logit scales\n",
+    "# Symlog scale\n",
     "ax = axs[2]\n",
-    "ax.format(yscale='symlog', yscale_kw={'linthresh': 1}, ylabel='symlog scale')\n",
+    "ax.format(yscale='symlog', ylabel='symlog scale')\n",
     "ax.plot(np.linspace(0, 1, N), np.linspace(-1000, 1000, N), lw=lw)\n",
+    "# Logit scale\n",
     "ax = axs[3]\n",
     "ax.format(yscale='logit', ylabel='logit scale')\n",
     "ax.plot(np.linspace(0, 1, N), np.linspace(0.01, 0.99, N), lw=lw)\n",
@@ -259,7 +266,7 @@
     "raw_mimetype": "text/restructuredtext"
    },
    "source": [
-    "ProPlot adds several new axis scales. The ``'cutoff'`` scale is great when you have weirdly distributed data (see `~proplot.axistools.CutoffScale`). The ``'sine'`` scale uses the sine function, resulting in an *area weighted* spherical latitude coordinate, and the ``'mercator'`` scale uses the Mercator projection latitude coordinate. The ``'inverse'`` scale is useful when working with spectral data (this is more useful with `~proplot.axes.XYAxes.dualx` and `~proplot.axes.XYAxes.dualy`; see :ref:`Dual unit axes`)."
+    "ProPlot adds several new axis scales. The ``'cutoff'`` scale is great when you have unusually distributed data (see `~proplot.axistools.CutoffScale`). The ``'sine'`` scale uses the sine function, resulting in an *area weighted* spherical latitude coordinate, and the ``'mercator'`` scale uses the Mercator projection latitude coordinate. The ``'inverse'`` scale is useful when working with spectral data (this is more useful with `~proplot.axes.XYAxes.dualx` and `~proplot.axes.XYAxes.dualy`; see :ref:`Dual unit axes`)."
    ]
   },
   {
@@ -296,7 +303,7 @@
     "    ax.format(xscale=('cutoff', *iargs), title=title,\n",
     "              xlim=(0, 4*np.pi), ylabel='wave amplitude',\n",
     "              xformatter='pi', xlocator=locator,\n",
-    "              xtickminor=False, xgrid=True, ygrid=False, suptitle='Cutoff scales demo')"
+    "              xtickminor=False, xgrid=True, ygrid=False, suptitle='Cutoff axis scales demo')"
    ]
   },
   {
@@ -308,9 +315,9 @@
     "import proplot as plot\n",
     "import numpy as np\n",
     "plot.rc.reset()\n",
-    "f, axs = plot.subplots(nrows=3, ncols=2, axwidth=1.5, share=0)\n",
-    "axs.format(rowlabels=[\n",
-    "    'Power\\nscales', 'Exponential\\nscales',  'Geographic\\nscales'], suptitle='Esoteric axis scales demo')\n",
+    "f, axs = plot.subplots(nrows=2, ncols=3, axwidth=1.6, share=0, order='F')\n",
+    "axs.format(collabels=['Power scales', 'Exponential scales',  'Cartographic scales'],\n",
+    "           suptitle='Additional axis scales demo')\n",
     "x = np.linspace(0, 1, 50)\n",
     "y = 10*x\n",
     "state = np.random.RandomState(51423)\n",
@@ -336,11 +343,10 @@
     "data = state.rand(len(x), len(y2))\n",
     "for ax, scale, color in zip(axs[4:], ('sine', 'mercator'), ('coral', 'sky blue')):\n",
     "    ax.plot(x, y, '-', color=color, lw=4)\n",
-    "    # Use 'right' to trim the colormap from 0-1 color range to 0-0.8 color range\n",
     "    ax.pcolormesh(x, y2, data, cmap='grays', cmap_kw={'right': 0.8})\n",
     "    ax.format(title=scale.title() + ' y-axis', yscale=scale,\n",
     "              ytickloc='left',\n",
-    "              yformatter='deglat', grid=False, ylocator=20,\n",
+    "              yformatter='deg', grid=False, ylocator=20,\n",
     "              xscale='linear', xlim=None, ylim=(-85, 85))"
    ]
   },
@@ -357,7 +363,9 @@
     "raw_mimetype": "text/restructuredtext"
    },
    "source": [
-    "The new `~proplot.axes.XYAxes.dualx` and `~proplot.axes.XYAxes.dualy` methods build duplicate *x* and *y* axes meant to represent *alternate units* in the same coordinate range as the \"parent\" axis. Both `~proplot.axes.XYAxes.dualx` and `~proplot.axes.XYAxes.dualy` accept either a *linear function*, a pair of arbitrary *forward and inverse* functions, or a *scale name or class*. In the latter case, the scale is passed to `~proplot.axistools.Scale` and its transforms are used for the forward and inverse functions."
+    "The new `~proplot.axes.XYAxes.dualx` and `~proplot.axes.XYAxes.dualy` methods build duplicate *x* and *y* axes meant to represent *alternate units* in the same coordinate range as the \"parent\" axis. Both `~proplot.axes.XYAxes.dualx` and `~proplot.axes.XYAxes.dualy` accept either a single linear *forward function*, a pair of arbitrary *forward and inverse functions*, or a *scale name or scale class*. In the latter case, the scale is passed to `~proplot.axistools.Scale`, its transforms are used for the forward and inverse functions, and its default locators and formatters are used for the `~proplot.axistools.FuncScale` default locators and formatters.\n",
+    "\n",
+    "Notably, the \"parent\" axis scale is now *arbitrary*. Below, in the first example, we draw \"dual unit\" axes with both *linear* and *symlog* parent scales. The next two examples demonstrate how to use specialized axis scales used for the forward and inverse transforms of the dual axes."
    ]
   },
   {
@@ -368,20 +376,28 @@
    "source": [
     "import proplot as plot\n",
     "plot.rc.update({'grid.alpha': 0.4, 'linewidth': 1, 'grid.linewidth': 1})\n",
-    "f, axs = plot.subplots(ncols=2, share=0, aspect=2.2, axwidth=3)\n",
+    "c1 = plot.shade('cerulean', 0.5)\n",
+    "c2 = plot.shade('red', 0.5)\n",
+    "f, axs = plot.subplots([[1, 1, 2, 2], [0, 3, 3, 0]],\n",
+    "                       share=0, aspect=2.2, axwidth=3)\n",
+    "axs.format(suptitle='Duplicate axes with custom transformations',\n",
+    "           xcolor=c1, gridcolor=c1,\n",
+    "           ylocator=[], yformatter=[])\n",
     "# Meters and kilometers\n",
     "ax = axs[0]\n",
-    "c1, c2 = plot.shade('cerulean', 0.5), plot.shade('red', 0.5)\n",
-    "ax.format(yformatter='null', xlabel='meters', xlocator=1000, xlim=(0, 5000),\n",
-    "          xcolor=c2, ylocator=[], gridcolor=c2,\n",
-    "          suptitle='Duplicate axes with custom transformations')\n",
-    "ax.dualx(lambda x: x*1e-3, label='kilometers', grid=True, color=c1)\n",
+    "ax.format(xlim=(0, 5000), xlabel='meters')\n",
+    "ax.dualx(lambda x: x*1e-3, label='kilometers',\n",
+    "         grid=True, color=c2, gridcolor=c2)\n",
     "# Kelvin and Celsius\n",
     "ax = axs[1]\n",
-    "ax.format(yformatter='null', xlabel='temperature (K)', title='', xlim=(200, 300), ylocator='null',\n",
-    "          xcolor=c2, gridcolor=c2)\n",
-    "ax.dualx(lambda x: x - 273.15,\n",
-    "         label='temperature (\\N{DEGREE SIGN}C)', grid=True, color=c1, gridcolor=c1)\n",
+    "ax.format(xlim=(200, 300), xlabel='temperature (K)')\n",
+    "ax.dualx(lambda x: x - 273.15, label='temperature (\\N{DEGREE SIGN}C)',\n",
+    "         grid=True, color=c2, gridcolor=c2)\n",
+    "# With symlog parent\n",
+    "ax = axs[2]\n",
+    "ax.format(xlim=(-100, 100), xscale='symlog', xlabel='MegaJoules')\n",
+    "ax.dualx(lambda x: x*1e6, label='Joules', formatter='log',\n",
+    "         grid=True, color=c2, gridcolor=c2)\n",
     "plot.rc.reset()"
    ]
   },
@@ -400,12 +416,14 @@
     "ax = axs[0]\n",
     "ax.format(xformatter='null', ylabel='pressure (hPa)',\n",
     "          ylim=(1000, 10), xlocator=[], ycolor=c1, gridcolor=c1)\n",
-    "ax.dualy('height', label='height (km)', ticks=2.5,\n",
+    "scale = plot.Scale('height')\n",
+    "ax.dualy(scale, label='height (km)', ticks=2.5,\n",
     "         color=c2, gridcolor=c2, grid=True)\n",
     "ax = axs[1]  # span\n",
     "ax.format(xformatter='null', ylabel='height (km)', ylim=(0, 20), xlocator='null',\n",
     "          grid=True, gridcolor=c2, ycolor=c2)\n",
-    "ax.dualy('pressure', label='pressure (hPa)', locator=100,\n",
+    "scale = plot.Scale('pressure')\n",
+    "ax.dualy(scale, label='pressure (hPa)', locator=100,\n",
     "         color=c1, gridcolor=c1, grid=True)\n",
     "plot.rc.reset()"
    ]
@@ -429,9 +447,9 @@
     "ax.axvline(cutoff, lw=2, ls='-', color=c2)\n",
     "ax.fill_between([cutoff - 0.03, cutoff + 0.03], 0, 1, color=c2, alpha=0.3)\n",
     "ax.plot(x, response, color=c1, lw=2)\n",
-    "ax.format(xlabel='wavenumber (days$^{-1}$)', ylabel='response', gridminor=True)\n",
-    "ax = ax.dualx('inverse', locator=[\n",
-    "    20, 10, 5, 2, 1, 0.5, 0.2, 0.1, 0.05], label='period (days)')\n",
+    "ax.format(xlabel='wavenumber (days$^{-1}$)', ylabel='response', grid=False)\n",
+    "scale = plot.Scale('inverse')\n",
+    "ax = ax.dualx(scale, locator='log', locator_kw={'subs': (1, 2, 5)}, label='period (days)')\n",
     "ax.format(title='Imaginary response function',\n",
     "          suptitle='Duplicate axes with wavenumber and period')\n",
     "plot.rc.reset()"

--- a/docs/colors_fonts.ipynb
+++ b/docs/colors_fonts.ipynb
@@ -134,7 +134,7 @@
    "outputs": [],
    "source": [
     "import proplot as plot\n",
-    "f = plot.show_fonts('DejaVu Sans', 'Fira Math', 'Helvetica', 'TeX Gyre Heros')"
+    "f = plot.show_fonts()"
    ]
   },
   {

--- a/proplot/axes.py
+++ b/proplot/axes.py
@@ -1603,11 +1603,13 @@ optional
     )
 
 
+# TODO: More systematic approach?
 dualxy_kwargs = (
     'label', 'locator', 'formatter', 'ticks', 'ticklabels',
     'minorlocator', 'minorticks', 'tickminor',
     'ticklen', 'tickrange', 'tickdir', 'ticklabeldir', 'tickrotation',
     'bounds', 'margin', 'color', 'grid', 'gridminor',
+    'locator_kw', 'formatter_kw', 'minorlocator_kw', 'label_kw',
 )
 
 dualxy_descrip = """
@@ -1616,38 +1618,20 @@ coordinates in *alternate units*.
 
 Parameters
 ----------
-forward : function, optional
-    Function used to transform units from the original axis to the
-    secondary axis. Should take 1 value and perform a *forward
-    linear transformation*. For example, to convert Kelvin to Celsius,
-    use ``ax.dual%(x)s(lambda x: x - 273.15)``. To convert kilometers to
-    meters, use ``ax.dual%(x)s(lambda x: x*1e3)``.
-inverse : function, optional
-    Function used to transform units from the secondary axis back to
-    the original axis. If `forward` was a non-linear function, you
-    *must* provide this, or the transformation will be incorrect!
-
-    For example, to apply the square, use
-    ``ax.dual%(x)s(lambda x: x**2, lambda x: x**0.5)``.
-scale : scale-spec, optional
-    The axis scale from which forward and inverse transformations
-    are inferred. Passed to `~proplot.axistools.Scale`.
-
-    For example, to apply the inverse, use ``ax.dual%(x)s('inverse')``;
-    To apply the base-10 exponential function, use
-    ``ax.dual%(x)s(('exp', 10, 1, 10))``
-    or ``ax.dual%(x)s(plot.Scale('exp', 10))``.
-scale_kw : dict-like, optional
-    Ignored if `scale` is ``None``. Passed to
-    `~proplot.axistools.Scale`.
+arg : function, (function, function), or `~matplotlib.scale.ScaleBase`
+    Used to transform units from the parent axis to the secondary axis.
+    This can be a `~proplot.axistools.FuncScale` itself or a function,
+    (function, function) tuple, or `~matplotlib.scale.ScaleBase` instance used
+    to *generate* a `~proplot.axistools.FuncScale` (see
+    `~proplot.axistools.FuncScale` for details).
 %(args)s : optional
-    Prepended with ``'y'`` and passed to `Axes.format`.
+    Prepended with ``'%(x)s'`` and passed to `Axes.format`.
 """
 
 altxy_descrip = """
 Alias and more intuitive name for `~XYAxes.twin%(y)s`.
-The matplotlib `~matplotlib.axes.Axes.twiny` function
-generates two *x* axes with a shared ("twin") *y* axis.
+The matplotlib `~matplotlib.axes.Axes.twin%(y)s` function
+generates two *%(x)s* axes with a shared ("twin") *%(y)s* axis.
 Enforces the following settings.
 
 * Places the old *%(x)s* axis on the %(x1)s and the new *%(x)s* axis

--- a/proplot/axistools.py
+++ b/proplot/axistools.py
@@ -1249,23 +1249,28 @@ class CutoffScale(_ScaleBase, mscale.ScaleBase):
         Parameters
         ----------
         *args : (thresh_1, scale_1, ..., thresh_N, [scale_N]), optional
-            Sequence of thresholds and scales. If the final scale is omitted
-            (i.e. you passed an odd number of args) it is set to ``1``.
+            Sequence of "thresholds" and "scales". If the final scale is
+            omitted (i.e. you passed an odd number of arguments) it is set
+            to ``1``. Each ``scale_i`` in the sequence can be interpreted
+            as follows:
 
             * If ``scale_i < 1``, the axis is decelerated from ``thresh_i`` to
-              ``thresh_i+1`` or, if ``i == N``, everywhere above ``thresh_i``.
+              ``thresh_i+1``. For ``scale_N``, the axis is decelerated
+              everywhere above ``thresh_N``.
             * If ``scale_i > 1``, the axis is accelerated from ``thresh_i`` to
-              ``thresh_i+1`` or, if ``i == N``, everywhere above ``thresh_i``.
-            * If ``scale_i == np.inf``, the axis *discretely jumps* from
-              ``thresh_i`` to ``thresh_i+1``.
+              ``thresh_i+1``. For ``scale_N``, the axis is accelerated
+              everywhere above ``thresh_N``.
+            * If ``scale_i == numpy.inf``, the axis *discretely jumps* from
+              ``thresh_i`` to ``thresh_i+1``. The final scale ``scale_N``
+              *cannot* be ``numpy.inf``.
 
         Example
         -------
 
         >>> import proplot as plot
         ... import numpy as np
-        ... scale = plot.CutoffScale(10, 2)  # go "twice as fast" after 10
-        ... scale = plot.CutoffScale(10, 0.5, 20)  # zoom in between 10 and 20
+        ... scale = plot.CutoffScale(10, 0.5)  # move slower above 10
+        ... scale = plot.CutoffScale(10, 2, 20)  # zoom out between 10 and 20
         ... scale = plot.CutoffScale(10, np.inf, 20)  # jump from 10 to 20
 
         """

--- a/proplot/axistools.py
+++ b/proplot/axistools.py
@@ -855,6 +855,11 @@ optional
                 }
                 kwargs['linthresh'] = inverse(kwargs['linthresh'])
                 parent_scale = SymmetricalLogScale(**kwargs)
+            elif isinstance(parent_scale, CutoffScale):
+                args = list(parent_scale.args)  # copy
+                for i in range(0, len(args), 2):
+                    args[i] = inverse(args[i])
+                parent_scale = CutoffScale(*args)
             functransform = parent_scale.get_transform() + functransform
         elif parent_scale is not None:
             raise ValueError(
@@ -1284,9 +1289,10 @@ class CutoffScale(_ScaleBase, mscale.ScaleBase):
         args = list(args)
         if len(args) % 2 == 1:
             args.append(1)
-        threshs = args[::2]
-        scales = args[1::2]
-        self._transform = CutoffTransform(threshs, scales)
+        self.args = args
+        self.threshs = args[::2]
+        self.scales = args[1::2]
+        self._transform = CutoffTransform(self.threshs, self.scales)
 
 
 class CutoffTransform(mtransforms.Transform):

--- a/proplot/axistools.py
+++ b/proplot/axistools.py
@@ -66,32 +66,34 @@ def Locator(locator, *args, **kwargs):
 
         If string, a dictionary lookup is performed (see below table).
 
-        ======================  ============================================  =========================================================================================
-        Key                     Class                                         Description
-        ======================  ============================================  =========================================================================================
-        ``'null'``, ``'none'``  `~matplotlib.ticker.NullLocator`              No ticks
-        ``'auto'``              `~matplotlib.ticker.AutoLocator`              Major ticks at sensible locations
-        ``'minor'``             `~matplotlib.ticker.AutoMinorLocator`         Minor ticks at sensible locations
-        ``'date'``              `~matplotlib.dates.AutoDateLocator`           Default tick locations for datetime axes
-        ``'log'``               `~matplotlib.ticker.LogLocator` preset        For log-scale axes, ticks on each power of the base
-        ``'logminor'``          `~matplotlib.ticker.LogLocator` preset        For log-scale axes, ticks on the 1st through 9th multiples of each power of the base
-        ``'maxn'``              `~matplotlib.ticker.MaxNLocator`              No more than ``N`` ticks at sensible locations
-        ``'linear'``            `~matplotlib.ticker.LinearLocator`            Exactly ``N`` ticks encompassing the axis limits, spaced as ``numpy.linspace(lo, hi, N)``
-        ``'multiple'``          `~matplotlib.ticker.MultipleLocator`          Ticks every ``N`` step away from zero
-        ``'fixed'``             `~matplotlib.ticker.FixedLocator`             Ticks at these exact locations
-        ``'index'``             `~matplotlib.ticker.IndexLocator`             Ticks on the non-negative integers
-        ``'symlog'``            `~matplotlib.ticker.SymmetricalLogLocator`    Ticks for symmetrical log-scale axes
-        ``'logit'``             `~matplotlib.ticker.LogitLocator`             Ticks for logit-scale axes
-        ``'theta'``             `~matplotlib.projections.polar.ThetaLocator`  Like the base locator but default locations are every `numpy.pi`/8 radians
-        ``'year'``              `~matplotlib.dates.YearLocator`               Ticks every ``N`` years
-        ``'month'``             `~matplotlib.dates.MonthLocator`              Ticks every ``N`` months
-        ``'weekday'``           `~matplotlib.dates.WeekdayLocator`            Ticks every ``N`` weekdays
-        ``'day'``               `~matplotlib.dates.DayLocator`                Ticks every ``N`` days
-        ``'hour'``              `~matplotlib.dates.HourLocator`               Ticks every ``N`` hours
-        ``'minute'``            `~matplotlib.dates.MinuteLocator`             Ticks every ``N`` minutes
-        ``'second'``            `~matplotlib.dates.SecondLocator`             Ticks every ``N`` seconds
-        ``'microsecond'``       `~matplotlib.dates.MicrosecondLocator`        Ticks every ``N`` microseconds
-        ======================  ============================================  =========================================================================================
+        ======================  =================================================  ================================================================================================
+        Key                     Class                                              Description
+        ======================  =================================================  ================================================================================================
+        ``'null'``, ``'none'``  `~matplotlib.ticker.NullLocator`                   No ticks
+        ``'auto'``              `~matplotlib.ticker.AutoLocator`                   Major ticks at sensible locations
+        ``'minor'``             `~matplotlib.ticker.AutoMinorLocator`              Minor ticks at sensible locations
+        ``'date'``              `~matplotlib.dates.AutoDateLocator`                Default tick locations for datetime axes
+        ``'fixed'``             `~matplotlib.ticker.FixedLocator`                  Ticks at these exact locations
+        ``'index'``             `~matplotlib.ticker.IndexLocator`                  Ticks on the non-negative integers
+        ``'linear'``            `~matplotlib.ticker.LinearLocator`                 Exactly ``N`` ticks encompassing the axis limits, spaced as ``numpy.linspace(lo, hi, N)``
+        ``'log'``               `~matplotlib.ticker.LogLocator`                    Ticks for log-scale axes
+        ``'logminor'``          `~matplotlib.ticker.LogLocator` preset             Ticks for log-scale axes on the 1st through 9th multiples of each power of the base
+        ``'logit'``             `~matplotlib.ticker.LogitLocator`                  Ticks for logit-scale axes
+        ``'logitminor'``        `~matplotlib.ticker.LogitLocator` preset           Ticks for logit-scale axes with ``minor=True`` passed to `~matplotlib.ticker.LogitLocator`
+        ``'maxn'``              `~matplotlib.ticker.MaxNLocator`                   No more than ``N`` ticks at sensible locations
+        ``'multiple'``          `~matplotlib.ticker.MultipleLocator`               Ticks every ``N`` step away from zero
+        ``'symlog'``            `~matplotlib.ticker.SymmetricalLogLocator`         Ticks for symmetrical log-scale axes
+        ``'symlogminor'``       `~matplotlib.ticker.SymmetricalLogLocator` preset  Ticks for symmetrical log-scale axes on the 1st through 9th multiples of each power of the base
+        ``'theta'``             `~matplotlib.projections.polar.ThetaLocator`       Like the base locator but default locations are every `numpy.pi`/8 radians
+        ``'year'``              `~matplotlib.dates.YearLocator`                    Ticks every ``N`` years
+        ``'month'``             `~matplotlib.dates.MonthLocator`                   Ticks every ``N`` months
+        ``'weekday'``           `~matplotlib.dates.WeekdayLocator`                 Ticks every ``N`` weekdays
+        ``'day'``               `~matplotlib.dates.DayLocator`                     Ticks every ``N`` days
+        ``'hour'``              `~matplotlib.dates.HourLocator`                    Ticks every ``N`` hours
+        ``'minute'``            `~matplotlib.dates.MinuteLocator`                  Ticks every ``N`` minutes
+        ``'second'``            `~matplotlib.dates.SecondLocator`                  Ticks every ``N`` seconds
+        ``'microsecond'``       `~matplotlib.dates.MicrosecondLocator`             Ticks every ``N`` microseconds
+        ======================  =================================================  ================================================================================================
 
     *args, **kwargs
         Passed to the `~matplotlib.ticker.Locator` class.
@@ -179,26 +181,26 @@ def Formatter(formatter, *args, date=False, index=False, **kwargs):
         ``'simple'``            `SimpleFormatter`                               New default tick labels for e.g. contour labels
         ``'frac'``              `FracFormatter`                                 Rational fractions
         ``'date'``              `~matplotlib.dates.AutoDateFormatter`           Default tick labels for datetime axes
-        ``'datestr'``           `~matplotlib.dates.DateFormatter`               Date formatting with C-style ``string % format`` notation
         ``'concise'``           `~matplotlib.dates.ConciseDateFormatter`        More concise date labels introduced in `matplotlib 3.1 <https://matplotlib.org/3.1.0/users/whats_new.html#concisedateformatter>`__
+        ``'datestr'``           `~matplotlib.dates.DateFormatter`               Date formatting with C-style ``string % format`` notation
+        ``'eng'``               `~matplotlib.ticker.EngFormatter`               Engineering notation
+        ``'fixed'``             `~matplotlib.ticker.FixedFormatter`             List of strings
+        ``'formatstr'``         `~matplotlib.ticker.FormatStrFormatter`         From C-style ``string % format`` notation
+        ``'index'``             `~matplotlib.ticker.IndexFormatter`             List of strings corresponding to non-negative integer positions along the axis
+        ``'log'``, ``'sci'``    `~matplotlib.ticker.LogFormatterSciNotation`    For log-scale axes with scientific notation
+        ``'logit'``             `~matplotlib.ticker.LogitFormatter`             For logistic-scale axes
+        ``'math'``              `~matplotlib.ticker.LogFormatterMathtext`       For log-scale axes with math text
+        ``'percent'``           `~matplotlib.ticker.PercentFormatter`           Trailing percent sign
         ``'scalar'``            `~matplotlib.ticker.ScalarFormatter`            Old default tick labels for axes
         ``'strmethod'``         `~matplotlib.ticker.StrMethodFormatter`         From the ``string.format`` method
-        ``'formatstr'``         `~matplotlib.ticker.FormatStrFormatter`         From C-style ``string % format`` notation
-        ``'log'``, ``'sci'``    `~matplotlib.ticker.LogFormatterSciNotation`    For log-scale axes with scientific notation
-        ``'math'``              `~matplotlib.ticker.LogFormatterMathtext`       For log-scale axes with math text
-        ``'logit'``             `~matplotlib.ticker.LogitFormatter`             For logistic-scale axes
-        ``'eng'``               `~matplotlib.ticker.EngFormatter`               Engineering notation
-        ``'percent'``           `~matplotlib.ticker.PercentFormatter`           Trailing percent sign
-        ``'fixed'``             `~matplotlib.ticker.FixedFormatter`             List of strings
-        ``'index'``             `~matplotlib.ticker.IndexFormatter`             List of strings corresponding to non-negative integer positions along the axis
         ``'theta'``             `~matplotlib.projections.polar.ThetaFormatter`  Formats radians as degrees, with a degree symbol
-        ``'pi'``                `FracFormatter` preset                          Fractions of :math:`\\pi`
         ``'e'``                 `FracFormatter` preset                          Fractions of *e*
+        ``'pi'``                `FracFormatter` preset                          Fractions of :math:`\\pi`
         ``'deg'``               `AutoFormatter` preset                          Trailing degree symbol
-        ``'deglon'``            `AutoFormatter` preset                          Trailing degree symbol and cardinal "WE" indicator
         ``'deglat'``            `AutoFormatter` preset                          Trailing degree symbol and cardinal "SN" indicator
-        ``'lon'``               `AutoFormatter` preset                          Cardinal "WE" indicator
+        ``'deglon'``            `AutoFormatter` preset                          Trailing degree symbol and cardinal "WE" indicator
         ``'lat'``               `AutoFormatter` preset                          Cardinal "SN" indicator
+        ``'lon'``               `AutoFormatter` preset                          Cardinal "WE" indicator
         ======================  ==============================================  ===================================================================================================================================
 
     date : bool, optional
@@ -290,30 +292,30 @@ def Scale(scale, *args, **kwargs):
         first element, the subsequent items are passed to the scale class as
         positional arguments.
 
-        =================  ===============================  =======================================================================
-        Key                Class                            Description
-        =================  ===============================  =======================================================================
-        ``'linear'``       `~matplotlib.scale.LinearScale`  Linear
-        ``'log'``          `LogScale`                       Logarithmic
-        ``'symlog'``       `SymmetricalLogScale`            Logarithmic beyond finite space around zero
-        ``'logit'``        `~matplotlib.scale.LogitScale`   Logistic
-        ``'inverse'``      `InverseScale`                   Inverse
-        ``'function'``     `FuncScale`                      Scale from arbitrary forward and backwards functions
-        ``'sine'``         `SineLatitudeScale`              Sine function (in degrees)
-        ``'mercator'``     `MercatorLatitudeScale`          Mercator latitude function (in degrees)
-        ``'exp'``          `ExpScale`                       Arbitrary exponential function
-        ``'power'``        `PowerScale`                     Arbitrary power function
-        ``'cutoff'``       `CutoffScale`                    Arbitrary piecewise linear transformations
-        ``'quadratic'``    `PowerScale` (preset)            Quadratic function
-        ``'cubic'``        `PowerScale` (preset)            Cubic function
-        ``'quartic'``      `PowerScale` (preset)            Cubic function
-        ``'pressure'``     `ExpScale` (preset)              Height (in km) expressed linear in pressure
-        ``'height'``       `ExpScale` (preset)              Pressure (in hPa) expressed linear in height
-        ``'db'``           `ExpScale` (preset)              Ratio expressed as `decibels <https://en.wikipedia.org/wiki/Decibel>`__
-        ``'np'``           `ExpScale` (preset)              Ratio expressed as `nepers <https://en.wikipedia.org/wiki/Neper>`__
-        ``'idb'``          `ExpScale` (preset)              `Decibels <https://en.wikipedia.org/wiki/Decibel>`__ expressed as ratio
-        ``'inp'``          `ExpScale` (preset)              `Nepers <https://en.wikipedia.org/wiki/Neper>`__ expressed as ratio
-        =================  ===============================  =======================================================================
+        =================  =======================  =======================================================================
+        Key                Class                    Description
+        =================  =======================  =======================================================================
+        ``'linear'``       `LinearScale`            Linear
+        ``'log'``          `LogScale`               Logarithmic
+        ``'symlog'``       `SymmetricalLogScale`    Logarithmic beyond finite space around zero
+        ``'logit'``        `LogitScale`             Logistic
+        ``'inverse'``      `InverseScale`           Inverse
+        ``'function'``     `FuncScale`              Scale from arbitrary forward and backwards functions
+        ``'sine'``         `SineLatitudeScale`      Sine function (in degrees)
+        ``'mercator'``     `MercatorLatitudeScale`  Mercator latitude function (in degrees)
+        ``'exp'``          `ExpScale`               Arbitrary exponential function
+        ``'power'``        `PowerScale`             Arbitrary power function
+        ``'cutoff'``       `CutoffScale`            Arbitrary piecewise linear transformations
+        ``'quadratic'``    `PowerScale` (preset)    Quadratic function
+        ``'cubic'``        `PowerScale` (preset)    Cubic function
+        ``'quartic'``      `PowerScale` (preset)    Cubic function
+        ``'db'``           `ExpScale` (preset)      Ratio expressed as `decibels <https://en.wikipedia.org/wiki/Decibel>`__
+        ``'np'``           `ExpScale` (preset)      Ratio expressed as `nepers <https://en.wikipedia.org/wiki/Neper>`__
+        ``'idb'``          `ExpScale` (preset)      `Decibels <https://en.wikipedia.org/wiki/Decibel>`__ expressed as ratio
+        ``'inp'``          `ExpScale` (preset)      `Nepers <https://en.wikipedia.org/wiki/Neper>`__ expressed as ratio
+        ``'pressure'``     `ExpScale` (preset)      Height (in km) expressed linear in pressure
+        ``'height'``       `ExpScale` (preset)      Pressure (in hPa) expressed linear in height
+        =================  =======================  =======================================================================
 
     *args, **kwargs
         Passed to the `~matplotlib.scale.ScaleBase` class.

--- a/proplot/axistools.py
+++ b/proplot/axistools.py
@@ -557,6 +557,12 @@ def _parse_logscale_args(kwargs, *keys):
             kwargs.pop(key + 'y', None),
             None, names=(key, key + 'x', key + 'y'),
         )
+        if key == 'linthresh' and value is None:
+            # NOTE: If linthresh is *exactly* on a power of the base, can
+            # end up with additional log-locator step inside the threshold,
+            # e.g. major ticks on -10, -1, -0.1, 0.1, 1, 10 for linthresh of
+            # 1. Adding slight offset to *desired* linthresh prevents this.
+            value = 1 + 1e-10
         if key == 'subs' and value is None:
             value = np.arange(1, 10)
         if value is not None:  # dummy axis_name is 'x'

--- a/proplot/axistools.py
+++ b/proplot/axistools.py
@@ -292,9 +292,12 @@ def Scale(scale, *args, **kwargs):
         If `~matplotlib.scale.ScaleBase`, the object is returned.
 
         If string, this is the registered scale name or scale "preset" (see
-        below table). If an iterable is passed with the scale name as the
-        first element, the subsequent items are passed to the scale class as
-        positional arguments.
+        below table).
+
+        If list or tuple and the first element is a string, the subsequent
+        items are passed to the scale class as positional arguments. For
+        example, ``ax.format(xscale=('power', 2))`` applies the ``'quadratic'``
+        scale to the *x* axis.
 
         =================  =======================  =======================================================================
         Key                Class                    Description
@@ -329,6 +332,10 @@ def Scale(scale, *args, **kwargs):
     `~matplotlib.scale.ScaleBase`
         The scale instance.
     """  # noqa
+    # NOTE: Why not try to interpret FuncScale arguments, like when lists
+    # of numbers are passed to Locator? Because FuncScale *itself* accepts
+    # ScaleBase classes as arguments... but constructor functions cannot
+    # do anything but return the class instance upon receiving one.
     if isinstance(scale, mscale.ScaleBase):
         return scale
     # Pull out extra args

--- a/proplot/styletools.py
+++ b/proplot/styletools.py
@@ -3625,7 +3625,7 @@ def show_fonts(*args, size=12, text=None):
     # Create figure
     f, axs = subplots(
         ncols=1, nrows=len(args), space=0,
-        axwidth=4.5, axheight=(text.count('\n') + 3.5) * size / 72,
+        axwidth=4.5, axheight=1.2 * (text.count('\n') + 2.5) * size / 72,
         fallback_to_cm=False
     )
     axs.format(xloc='neither', yloc='neither',

--- a/proplot/wrappers.py
+++ b/proplot/wrappers.py
@@ -1351,7 +1351,7 @@ def text_wrapper(
         if not isinstance(fontname, str) and np.iterable(
                 fontname) and len(fontname) == 1:
             fontname = fontname[0]
-        if fontname in styletools.fonts:
+        if fontname.lower() in list(map(str.lower, styletools.fonts)):
             kwargs['fontfamily'] = fontname
         else:
             _warn_proplot(


### PR DESCRIPTION
This PR improves the "dual" axis scale feature, makes the `xminorticks`/`yminorticks` `Axes.format` "toggle" always use the *default* minor locator for the minor scale, cleans up `_ScaleBase`, changes the default `symlog` subs and linthresh, and fixes the default `LogitScale` formatters and locators.

Edit: It also fixes various bugs associated with non-linear "parent" axis scales and "dual" axes.