### PR TITLE
Remove ipython funcs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,31 +12,69 @@ Changelog history
 
 ProPlot v1.0.0 (2020-##-##)
 ===========================
-This will be published when some major refactoring tasks are completed.
-See :pr:`45`, :pr:`46`, and :pr:`50`.
+This will be published when some major refactoring tasks are completed,
+and deprecation warnings will be removed. See :pr:`89`, :pr:`109`, :pr:`110`,
+and :pr:`111`.
 
 ProPlot v0.5.0 (2020-##-##)
 ===========================
+.. rubric:: Deprecated
+
+- `~proplot.axes.Axes.format` functions have been deprecated in favor of the
+  axes-artist `~matplotlib.artist.Artist.set` override (:pr:`89`).
+
 .. rubric:: Features
 
-- Users can now use `~proplot.subplots.figure` with `~proplot.subplots.Figure.add_subplot`
-  *or* `~proplot.subplots.subplots` (:pr:`50`). This is a major improvement!
+- All features are now implemented with individual *setters*, like in matplotlib,
+  but we still encourage using the bulk ``set`` method through documentation
+  examples and by populating the ``set`` docstring (so valid arguments are no
+  longer implicit).
+- Users can now use `~proplot.subplots.figure` with
+  `~proplot.subplots.Figure.add_subplot`
+  *or* `~proplot.subplots.subplots` (:pr:`110`). This is a major improvement!
 - `~proplot.subplots.GridSpec` now accepts physical units, rather than having
-  `~proplot.subplots.subplots` handle the units (:pr:`50`).
+  `~proplot.subplots.subplots` handle the units (:pr:`110`).
 - Allow "hanging" twin *x* and *y* axes as members of the `~proplot.subplots.EdgeStack`
   container. Arbitrarily many siblings are now permitted.
 - Use `~proplot.subplots.GeometrySolver` for calculating various automatic layout
-  stuff instead of having 1000 hidden `~proplot.subplots.Figure` methods (:pr:`50`).
+  stuff instead of having 1000 hidden `~proplot.subplots.Figure` methods (:pr:`110`).
 - Use `~proplot.subplots.EdgeStack` class for handling
-  stacks of colorbars, legends, and text (:pr:`50`).
+  stacks of colorbars, legends, and text (:pr:`110`).
 
 .. rubric:: Internals
 
+- Assignments to `~proplot.rctools.rc_configurator` are now validated, and the
+  configurator is now a monkey patch of `~matplotlib.rcParams` (:pr:`109`).
+- Plotting wrapper features (e.g. `~proplot.wrappers.standardize_1d`) are now
+  implemented and documented on the individual methods themselves
+  (e.g. `~proplot.axes.Axes.plot`; :pr:`111`).
+  This is much easier for new users.
 - Handle all projection keyword arguments in `~proplot.subplots.Figure.add_subplot`
-  instead of `~proplot.subplots.subplots` (:pr:`50`).
+  instead of `~proplot.subplots.subplots` (:pr:`110`).
 - Panels, colorbars, and legends are now members of `~proplot.subplots.EdgeStack`
   stacks rather than getting inserted directly into
-  the main `~proplot.subplots.GridSpec` (:pr:`50`).
+  the main `~proplot.subplots.GridSpec` (:pr:`110`).
+
+ProPlot v0.4.3 (2020-01-21)
+===========================
+.. rubric:: Deprecated
+
+- Remove `~proplot.rctools.ipython_autoreload`,
+  `~proplot.rctools.ipython_autosave`, and `~proplot.rctools.ipython_matplotlib`
+  (:issue:`112`, :pr:`113`). Move inline backend configuration to a hidden
+  method that gets called whenever the ``rc_configurator`` is initalized.
+
+.. rubric:: Features
+
+- Permit comments at the head of colormap and color files (:commit:`0ffc1d15`).
+- Make `~proplot.axes.Axes.parametric` match ``plot`` autoscaling behavior
+  (:commit:`ecdcba82`).
+
+.. rubric:: Internals
+
+- Use `~proplot.axes.Axes.colorbar` instead of `~matplotlib.axes.Axes.imshow`
+  for `~proplot.styletools.show_cmaps` and `~proplot.styletools.show_cycles`
+  displays (:pr:`107`).
 
 ProPlot v0.4.2 (2020-01-09)
 ===========================
@@ -290,7 +328,7 @@ ProPlot v0.2.0 (2019-12-02)
 - Rename the ``format`` rc setting in favor of the ``inlinefmt`` setting
   (:commit:`3a622887`; ``format`` is still accepted but no longer documented).
 - Rename ``FlexibleGridSpec`` and ``FlexibleSubplotSpec`` to ``GridSpec``
-  and ``SubplotSpec`` (:commit:`3a622887`; until :pr:`50` is merged it is impossible
+  and ``SubplotSpec`` (:commit:`3a622887`; until :pr:`110` is merged it is impossible
   to use these manually, so this won't bother anyone).
 
 .. rubric:: Features

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -47,8 +47,6 @@ Key               Description
 ``abc``           Boolean, whether to draw a-b-c labels by default.
 ``align``         Whether to align axis labels during draw. See `aligning labels <https://matplotlib.org/3.1.1/gallery/subplots_axes_and_figures/align_labels_demo.html>`__.
 ``alpha``         The opacity of the background axes patch.
-``autoreload``    If not empty or ``0``, passed to `%autoreload <https://ipython.readthedocs.io/en/stable/config/extensions/autoreload.html#magic-autoreload>`__.
-``autosave``      If not empty or ``0``, passed to `%autosave <https://www.webucator.com/blog/2016/03/change-default-autosave-interval-in-ipython-notebook/>`__.
 ``borders``       Boolean, toggles country border lines on and off.
 ``cmap``          The default colormap.
 ``coast``         Boolean, toggles coastline lines on and off.
@@ -68,7 +66,6 @@ Key               Description
 ``linewidth``     Thickness of axes spines and major tick lines.
 ``lut``           The number of colors to put in the colormap lookup table.
 ``margin``        The margin of space between axes edges and objects plotted inside the axes, if ``xlim`` and ``ylim`` are unset.
-``matplotlib``    If not empty, passed to `%matplotlib <https://ipython.readthedocs.io/en/stable/interactive/magics.html#magic-matplotlib>`__. If ``'auto'`` (the default) uses ``'inline'`` for notebooks and ``'osx'`` or ``'qt'`` for other ipython sessions.
 ``ocean``         Boolean, toggles ocean patches on and off.
 ``reso``          Resolution of geographic features, one of ``'lo'``, ``'med'``, or ``'hi'``
 ``rgbcycle``      If ``True``, and ``colorblind`` is the current cycle, this registers the ``colorblind`` colors as ``'r'``, ``'b'``, ``'g'``, etc., like in `seaborn <https://seaborn.pydata.org/tutorial/color_palettes.html>`__.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -34,8 +34,6 @@ We recommend importing ProPlot as follows:
 This differentiates ProPlot from the usual ``plt`` abbreviation used for the `~matplotlib.pyplot` module.
 Importing ProPlot immediately adds several new colormaps, property cyclers, color names, and fonts to matplotlib. See :ref:`Colormaps`, :ref:`Color cycles`, and :ref:`Colors and fonts` for details.
 
-Importing ProPlot also configures your IPython environment by setting up the matplotlib backend and enabling the autoreload and autosave extensions (this feature can be disabled). See `~proplot.rctools.ipython_matplotlib`, `~proplot.rctools.ipython_autoreload`, and `~proplot.rctools.ipython_autosave` for details.
-
 Figure and axes classes
 =======================
 Making figures in ProPlot always begins with a call to the
@@ -95,4 +93,4 @@ of the `~proplot.subplots.Figure` and `~proplot.axes.Axes` subclasses.
 * The `~proplot.styletools.show_cmaps`, `~proplot.styletools.show_cycles`, `~proplot.styletools.show_colors`, `~proplot.styletools.show_fonts`, `~proplot.styletools.show_channels`, and `~~proplot.styletools.show_colorspaces` functions are used to visualize your color scheme and font options and inspect individual colormaps.
 * The `~proplot.styletools.Norm` constructor function generates colormap normalizers from shorthand names. The new `~proplot.styletools.LinearSegmentedNorm` normalizer scales colors evenly w.r.t. index for arbitrarily spaced monotonic levels, and the new `~proplot.styletools.BinNorm` meta-normalizer is used to discretized colormap colors. See :ref:`2d plotting` for details.
 * The `~proplot.axistools.Locator`, `~proplot.axistools.Formatter`, and `~proplot.axistools.Scale` constructor functions, used to generate class instances from variable input types. These are used to interpret keyword arguments passed to `~proplot.axes.Axes.format` and `~proplot.subplots.Figure.colorbar`. See :ref:`X and Y axis settings` for details.
-* The `~proplot.rctools.rc` object, an instance of `~proplot.rctools.rc_configurator`, is used for modifying *individual* global settings, changing settings in *bulk*, and temporarily changing settings in *context blocks*. You can also control settings with a ``~/.proplotrc`` file. See :ref:`Configuring proplot` for details.
+* The `~proplot.rctools.rc` object, an instance of `~proplot.rctools.rc_configurator`, is used for modifying *individual* global settings, changing settings in *bulk*, and temporarily changing settings in *context blocks*. It also sets up the inline plotting backend, so that your inline figures look the same as your saved figures. See :ref:`Configuring proplot` for details.

--- a/proplot/__init__.py
+++ b/proplot/__init__.py
@@ -9,6 +9,8 @@ from .utils import *  # noqa: F401 F403
 with _benchmark('total time'):
     with _benchmark('styletools'):
         from .styletools import *  # noqa: F401 F403
+    with _benchmark('pyplot'):
+        import matplotlib.pyplot as _  # noqa; sets up the backend and ipython display hooks
     with _benchmark('rctools'):
         from .rctools import *  # noqa: F401 F403
     with _benchmark('axistools'):

--- a/proplot/rctools.py
+++ b/proplot/rctools.py
@@ -19,12 +19,11 @@ try:  # use this for debugging instead of print()!
 except ImportError:  # graceful fallback if IceCream isn't installed
     ic = lambda *a: None if not a else (a[0] if len(a) == 1 else a)  # noqa
 try:
-    import IPython
     from IPython import get_ipython
-except ModuleNotFoundError:
+except ImportError:
     def get_ipython():
         return
-from .utils import _warn_proplot, _counter, _benchmark, units
+from .utils import _warn_proplot, _counter, units
 
 # Disable mathtext "missing glyph" warnings
 import matplotlib.mathtext  # noqa
@@ -33,8 +32,7 @@ logger = logging.getLogger('matplotlib.mathtext')
 logger.setLevel(logging.ERROR)  # suppress warnings!
 
 __all__ = [
-    'rc', 'rc_configurator', 'ipython_autosave',
-    'ipython_autoreload', 'ipython_matplotlib',
+    'rc', 'rc_configurator', 'inline_backend_config',
 ]
 
 # Dictionaries used to track custom proplot settings
@@ -46,8 +44,6 @@ defaultParamsShort = {
     'abc': False,
     'align': False,
     'alpha': 1,
-    'autoreload': 2,
-    'autosave': 30,
     'borders': False,
     'cmap': 'fire',
     'coast': False,
@@ -67,7 +63,6 @@ defaultParamsShort = {
     'linewidth': 0.6,
     'lut': 256,
     'margin': 0.0,
-    'matplotlib': 'auto',
     'ocean': False,
     'reso': 'lo',
     'rgbcycle': False,
@@ -429,6 +424,10 @@ def _get_synced_params(key, value):
     if '.' in key:
         pass
 
+    # Backend
+    elif key == 'inlinefmt':
+        inline_backend_config(value)
+
     # Cycler
     elif key in ('cycle', 'rgbcycle'):
         if key == 'rgbcycle':
@@ -543,7 +542,7 @@ def _get_synced_params(key, value):
         kw['axes.grid'] = value
         kw['axes.grid.which'] = which
 
-    # Now update linked settings
+    # Update setting in dictionary, detect invalid keys
     value = _to_points(key, value)
     if key in rcParamsShort:
         kw_short[key] = value
@@ -553,6 +552,8 @@ def _get_synced_params(key, value):
         kw[key] = value
     else:
         raise KeyError(f'Invalid key {key!r}.')
+
+    # Update linked settings
     for name in _rc_children.get(key, ()):
         if name in rcParamsLong:
             kw_long[name] = value
@@ -736,9 +737,8 @@ class rc_configurator(object):
     Magical abstract class for managing matplotlib
     `rcParams <https://matplotlib.org/users/customizing.html>`__
     and additional ProPlot :ref:`rcParamsLong` and :ref:`rcParamsShort`
-    settings. When initialized, this loads defaults settings plus any user
-    overrides in the ``~/.proplotrc`` file. See the `~proplot.rctools`
-    documentation for details.
+    settings. This loads the default ProPlot settings and the
+    user ``.proplotrc`` overrides. See :ref:`Configuring proplot` for details.
     """
     def __contains__(self, key):
         return key in rcParamsShort or key in rcParamsLong or key in rcParams
@@ -768,10 +768,14 @@ class rc_configurator(object):
             Whether to load overrides from local and user ``.proplotrc``
             file(s). Default is ``True``.
         """
-        # Attributes and style
+        # Remove context objects
         object.__setattr__(self, '_context', [])
-        with _benchmark('  use'):
-            style.use('default')
+
+        # Set default style
+        # NOTE: Previously, style.use would trigger first pyplot import because
+        # rcParams.__getitem__['backend'] imports pyplot.switch_backend() so it
+        # can determine the default backend.
+        style.use('default')
 
         # Update from defaults
         rcParams.update(defaultParams)
@@ -861,12 +865,6 @@ class rc_configurator(object):
         """Modify an `rcParams \
 <https://matplotlibcorg/users/customizing.html>`__,
         :ref:`rcParamsLong`, and :ref:`rcParamsShort` setting(s)."""
-        if key == 'matplotlib':
-            return ipython_matplotlib(value)
-        elif key == 'autosave':
-            return ipython_autosave(value)
-        elif key == 'autoreload':
-            return ipython_autoreload(value)
         rc_short, rc_long, rc = _get_synced_params(key, value)
         rcParamsShort.update(rc_short)
         rcParamsLong.update(rc_long)
@@ -1129,66 +1127,33 @@ class rc_configurator(object):
             yield self[key]
 
 
-def ipython_matplotlib(backend=None, fmt=None):
+def inline_backend_config(fmt=None):
     """
-    Set up the `matplotlib backend \
+    Set up the `ipython inline backend \
 <https://ipython.readthedocs.io/en/stable/interactive/magics.html#magic-matplotlib>`__
-    for ipython sessions and apply the following ``%config InlineBackend``
-    magic commands.
+    format and ensure that inline figures always look the same as saved
+    figures. This runs the following ipython magic commands:
 
     .. code-block:: ipython
 
-        %config InlineBackend.figure_formats = fmt
-        %config InlineBackend.rc = {}  # never override my rc settings!
+        %config InlineBackend.figure_formats = rc['inlinefmt']
+        %config InlineBackend.rc = {}  # never override the rc settings
         %config InlineBackend.close_figures = True  # memory issues
         %config InlineBackend.print_figure_kwargs = {'bbox_inches': None}  \
-# we use our own tight layout algorithm
+# not 'tight', because proplot has its own tight layout algorithm
 
-    This must be called *before drawing any figures*! For some ipython
-    sessions (e.g. terminals) the backend can only be changed by adding
-    ``matplotlib: backend`` to your ``.proplotrc`` file.
-    See :ref:`Configuring proplot` for details.
+    When the inline backend is inactive or unavailable, this has no effect.
 
     Parameters
     ----------
-    backend : str, optional
-        The backend name. The default is ``'auto'``, which applies
-        ``%matplotlib inline`` for notebooks and ``%matplotlib qt`` for
-        all other sessions.
-
-        Note that when using the qt backend on macOS, you may want to prevent
-        "tabbed" figure windows by navigating to Settings...Dock and changing
-        "Prefer tabs when opening documents" to "Manually" (see \
-`Issue #13164 <https://github.com/matplotlib/matplotlib/issues/13164>`__).
     fmt : str or list of str, optional
-        The inline backend file format(s). Valid formats include ``'jpg'``,
-        ``'png'``, ``'svg'``, ``'pdf'``, and ``'retina'``. This is ignored
-        for non-inline backends.
+        The inline backend file format(s). Default is :rc:`inlinefmt`.
+        Valid formats include ``'jpg'``, ``'png'``, ``'svg'``, ``'pdf'``,
+        and ``'retina'``.
     """  # noqa
-    # Bail out
+    # Note if inline backend is unavailable this will fail silently
     ipython = get_ipython()
-    backend = backend or rcParamsShort['matplotlib']
-    if ipython is None or backend is None:
-        return
-
-    # Default behavior dependent on type of ipython session
-    # See: https://stackoverflow.com/a/22424821/4970632
-    ibackend = backend
-    if backend == 'auto':
-        if 'IPKernelApp' in getattr(get_ipython(), 'config', ''):
-            ibackend = 'inline'
-        else:
-            ibackend = 'qt'
-    try:
-        ipython.magic('matplotlib ' + ibackend)
-        if 'rc' in globals():  # should always be True, but just in case
-            rc.reset()
-    except KeyError:
-        if backend != 'auto':
-            _warn_proplot(f'{"%matplotlib " + backend!r} failed.')
-
-    # Configure inline backend
-    if ibackend != 'inline':
+    if ipython is None:
         return
     fmt = fmt or rcParamsShort['inlinefmt']
     if isinstance(fmt, str):
@@ -1202,67 +1167,10 @@ def ipython_matplotlib(backend=None, fmt=None):
         )
     ipython.magic('config InlineBackend.figure_formats = ' + repr(fmt))
     ipython.magic('config InlineBackend.rc = {}')  # no notebook overrides
-    ipython.magic('config InlineBackend.close_figures = True')  # memory issues
+    ipython.magic('config InlineBackend.close_figures = True')  # memory
     ipython.magic(  # use ProPlot tight layout instead
         'config InlineBackend.print_figure_kwargs = {"bbox_inches": None}'
     )
-
-
-def ipython_autoreload(autoreload=None):
-    """
-    Set up the `ipython autoreload utility \
-<https://ipython.readthedocs.io/en/stable/config/extensions/autoreload.html>`__
-    by running the following ipython magic.
-
-    .. code-block:: ipython
-
-        %autoreload autoreload
-
-    This is called on import by default. Add ``autoreload:`` to your
-    ``.proplotrc`` to disable. See :ref:`Configuring proplot` for details.
-
-    Parameters
-    ----------
-    autoreload : float, optional
-        The autoreload level. Default is :rc:`autoreload`.
-    """  # noqa
-    ipython = get_ipython()
-    autoreload = autoreload or rcParamsShort['autoreload']
-    if ipython is None or autoreload is None:
-        return
-    if 'autoreload' not in ipython.magics_manager.magics['line']:
-        with IPython.utils.io.capture_output():  # capture annoying message
-            ipython.magic('load_ext autoreload')
-    ipython.magic('autoreload ' + str(autoreload))
-
-
-def ipython_autosave(autosave=None):
-    """
-    Set up the `ipython autosave utility \
-<https://ipython.readthedocs.io/en/stable/interactive/magics.html#magic-matplotlib>`__
-    by running the following ipython magic.
-
-    .. code-block:: ipython
-
-        %autosave autosave
-
-    This is called on import by default. Add ``autosave:`` to your
-    ``.proplotrc`` to disable. See :ref:`Configuring proplot` for details.
-
-    Parameters
-    ----------
-    autosave : float, optional
-        The autosave interval in seconds. Default is :rc:`autosave`.
-    """  # noqa
-    ipython = get_ipython()
-    autosave = autosave or rcParamsShort['autosave']
-    if ipython is None or autosave is None:
-        return
-    with IPython.utils.io.capture_output():  # capture annoying message
-        try:
-            ipython.magic('autosave ' + str(autosave))
-        except IPython.core.error.UsageError:
-            pass
 
 
 # Write defaults
@@ -1273,10 +1181,3 @@ if not os.path.exists(_user_rc_file):
 #: Instance of `rc_configurator`. This is used to change global settings.
 #: See :ref:`Configuring proplot` for details.
 rc = rc_configurator()
-
-# Manually call setup functions after rc has been instantiated
-# We cannot call these inside rc.__init__ because ipython_matplotlib may
-# need to reset the configurator to overwrite backend-imposed settings!
-ipython_matplotlib()
-ipython_autoreload()
-ipython_autosave()

--- a/proplot/rctools.py
+++ b/proplot/rctools.py
@@ -32,7 +32,7 @@ logger = logging.getLogger('matplotlib.mathtext')
 logger.setLevel(logging.ERROR)  # suppress warnings!
 
 __all__ = [
-    'rc', 'rc_configurator', 'inline_backend_config',
+    'rc', 'rc_configurator', 'inline_backend_fmt',
 ]
 
 # Dictionaries used to track custom proplot settings
@@ -426,7 +426,7 @@ def _get_synced_params(key, value):
 
     # Backend
     elif key == 'inlinefmt':
-        inline_backend_config(value)
+        inline_backend_fmt(value)
 
     # Cycler
     elif key in ('cycle', 'rgbcycle'):
@@ -1127,7 +1127,7 @@ class rc_configurator(object):
             yield self[key]
 
 
-def inline_backend_config(fmt=None):
+def inline_backend_fmt(fmt=None):
     """
     Set up the `ipython inline backend \
 <https://ipython.readthedocs.io/en/stable/interactive/magics.html#magic-matplotlib>`__


### PR DESCRIPTION
Resolves #112 and removes the various `ipython` funcs. The `ipython_autoreload` and `ipython_autosave` funcs were unrelated to the goals of proplot and should have been included, and trying to change the backend at runtime was confusing for new users and impossible to get right in the case of `jupyter console`.