### PR TITLE
Permit descending colorbar levels

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -60,6 +60,8 @@ ProPlot v0.4.4 (2020-##-##)
 .. rubric:: Features
 
 - Add back `Fabio Crameri's scientific colour maps <http://www.fabiocrameri.ch/colourmaps.php>`__ (:pr:`116`).
+- Permit *descending* `~proplot.styletools.BinNorm` and `~proplot.styletools.LinearSegmentedNorm`
+  levels (:pr:`119`).
 - Permit overriding the font weight, style, and stretch in the
   `~proplot.styletools.show_fonts` table (:commit:`e8b9ee38`).
 - Permit hiding "unknown" colormaps and color cycles in the

--- a/proplot/axes.py
+++ b/proplot/axes.py
@@ -613,12 +613,13 @@ class Axes(maxes.Axes):
         return self.text(x, y, text, **kwextra)
 
     def format(
-            self, *, title=None, top=None,
-            figtitle=None, suptitle=None, rowlabels=None, collabels=None,
-            leftlabels=None, rightlabels=None,
-            toplabels=None, bottomlabels=None,
-            llabels=None, rlabels=None, tlabels=None, blabels=None,
-            **kwargs):
+        self, *, title=None, top=None,
+        figtitle=None, suptitle=None, rowlabels=None, collabels=None,
+        leftlabels=None, rightlabels=None,
+        toplabels=None, bottomlabels=None,
+        llabels=None, rlabels=None, tlabels=None, blabels=None,
+        **kwargs
+    ):
         """
         Modify the axes title(s), the a-b-c label, row and column labels, and
         the figure title. Called by `XYAxes.format`,


### PR DESCRIPTION
This PR will permit *descending* colorbar levels. This is not restoring a native matplotlib feature; it is a new proplot feature. I'm adding this simply because I wanted it for one of my plots.

The following example demonstrates how this works for both evenly spaced and unevenly spaced levels:

```python
import proplot as plot
import numpy as np
data = np.random.rand(20, 20).cumsum(axis=0)
for levels in (
    np.arange(0, 15, 1)[::-1],  # with Normalizer
    [15, 10, 5, 2, 1, 0],  # with LinearSegmentedNorm
):
    f, ax = plot.subplots()
    ax.pcolormesh(data, levels=levels, colorbar='b')
```

![image](https://user-images.githubusercontent.com/19657652/73885554-3ea1c380-4825-11ea-9a3f-943324af6a59.png)
![image](https://user-images.githubusercontent.com/19657652/73885547-39dd0f80-4825-11ea-8631-9cad21a5cb58.png)
