### PR TITLE
Update subplots.ipynb

### DIFF
--- a/docs/subplots.ipynb
+++ b/docs/subplots.ipynb
@@ -156,7 +156,7 @@
    "source": [
     "import proplot as plot\n",
     "f, axs = plot.subplots(\n",
-    "    ref=ref, nrows=3, ncols=3, axwidth=1.1, share=0\n",
+    "    nrows=3, ncols=3, axwidth=1.1, share=0\n",
     ")\n",
     "axs[4].format(\n",
     "    title='title\\ntitle\\ntitle',\n",


### PR DESCRIPTION
The `ref=ref` was probably left over from copy-pasting and is not needed here, right? I think this only works in this notebook because `ref` is set in a previous cell that loops over a set of `ref` values.