### PR TITLE
Add support for cartopy v0.18

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -117,6 +117,8 @@ There are quite a lot of deprecations for this release.
 
 - Support `cartopy 0.18 <https://scitools.org.uk/cartopy/docs/latest/whats_new.html>`__
   locators, formatters, deprecations, and new labelling features (:pr:`158`).
+- Add :rcraw:`geogrid.labelpad` and :rcraw:`geogrid.rotatelabels` settings
+  for cartopy gridline labels (:pr:`158`).
 - Support more `~proplot.ticker.AutoFormatter` features on
   `~proplot.ticker.SimpleFormatter` (:commit:`6decf962`).
 - Support drawing colorbars with descending levels (:commit:`10763146`)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -67,13 +67,9 @@ ProPlot v0.7.0 (2020-##-##)
 ProPlot v0.6.0 (2020-##-##)
 ===========================
 
-Rather than creating branches and opening pull requests, this release was
-developed by running the testing suite on my local machine and making commits
-directly to master. I will try to avoid this sort of workflow in the future.
-
 .. rubric:: Deprecated
 
-There are quite a lot of deprecations for this release. Since this is
+There are quite a lot of deprecations for this release.
 
 - Deprecate support for "parametric" plots inside `~matplotlib.axes.Axes.plot`,
   instead use `~proplot.axes.Axes.parametric` (:commit:`64210bce`).
@@ -114,11 +110,13 @@ There are quite a lot of deprecations for this release. Since this is
   `~proplot.styletools.LinearSegmentedColormap.truncated` to
   `~proplot.styletools.LinearSegmentedColormap.truncate`, and
   `~proplot.styletools.LinearSegmentedColormap.punched` to
-  `~proplot.styletools.LinearSegmentedColormap.cut` (:pr:`e1a08930`).  The old
+  `~proplot.styletools.LinearSegmentedColormap.cut` (:commit:`e1a08930`).  The old
   method names remain with a deprecation warning.
 
 .. rubric:: Features
 
+- Support `cartopy 0.18 <https://scitools.org.uk/cartopy/docs/latest/whats_new.html>`__
+  locators, formatters, deprecations, and new labelling features (:pr:`158`).
 - Support more `~proplot.ticker.AutoFormatter` features on
   `~proplot.ticker.SimpleFormatter` (:commit:`6decf962`).
 - Support drawing colorbars with descending levels (:commit:`10763146`)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -135,7 +135,7 @@ Finally, the ``geoaxes``, ``land``, ``ocean``, ``rivers``, ``lakes``,
 the corresponding :ref:`quick settings <rc_quick>` are turned on.
 
 ===============================  =========================================================================================================================================================================================================================================================
-Key(s)                           Description
+Key                              Description
 ===============================  =========================================================================================================================================================================================================================================================
 ``abc.style``                    a-b-c label style. For options, see `~proplot.axes.Axes.format`.
 ``abc.loc``                      a-b-c label position. For options, see `~proplot.axes.Axes.format`.
@@ -165,11 +165,17 @@ Key(s)                           Description
 ``geoaxes.facecolor``            Face color for the map outline patch.
 ``geoaxes.edgecolor``            Edge color for the map outline patch.
 ``geoaxes.linewidth``            Edge width for the map outline patch.
+``geogrid.alpha``                Opacity of geographic gridlines.
+``geogrid.color``                Color of geographic gridlines.
+``geogrid.labelpad``             Default padding in points between map boundary edge and longitude/latitude labels.
 ``geogrid.labels``               Boolean, indicates whether to label the parallels and meridians.
 ``geogrid.labelsize``            Font size for latitude and longitude labels. Inherits from ``small``.
 ``geogrid.latmax``               Absolute latitude in degrees, poleward of which meridian gridlines are cut off.
-``geogrid.lonstep``              Default interval for meridian gridlines in degrees.
 ``geogrid.latstep``              Default interval for parallel gridlines in degrees.
+``geogrid.linestyle``            Line style for geographic gridlines.
+``geogrid.linewidth``            line width for geographic gridlines.
+``geogrid.lonstep``              Default interval for meridian gridlines in degrees.
+``geogrid.rotatelabels``         Whether to rotate meridian and parallel gridline labels on cartopy axes.
 ``gridminor.linewidth``          Minor gridline width.
 ``gridminor.linestyle``          Minor gridline style.
 ``gridminor.alpha``              Minor gridline transparency.

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - xarray
   - pandas
   - matplotlib
-  - cartopy=0.17
+  - cartopy
   - basemap
   - pandoc
   - ipykernel

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,5 +1,7 @@
 # Hard requirements for notebook examples and documentation build
 # Proplot itself just needs matplotlib
+# NOTE: Basemap is broken as of matplotlib >=3.3 so for documentation
+# use 3.2.1. Probably lots of basemap holdouts for next ~5 years.
 # NOTE: PyQt5 is needed by pyplot, RTD server *happens* to already have it
 # but creating local environment will fail.
 name: proplot-dev
@@ -10,7 +12,7 @@ dependencies:
   - numpy
   - xarray
   - pandas
-  - matplotlib
+  - matplotlib==3.2.1
   - cartopy
   - basemap
   - pandoc

--- a/docs/projections.py
+++ b/docs/projections.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # ---
 # jupyter:
 #   jupytext:
@@ -5,7 +6,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.3.0
+#       jupytext_version: 1.4.2
 #   kernelspec:
 #     display_name: Python 3
 #     language: python
@@ -98,7 +99,7 @@ axs[2].format(
 # default, but you can switch to basemap using ``basemap=True``.
 # When you request map projections, `~proplot.ui.subplots` returns
 # instances of `~proplot.axes.CartopyAxes` or `~proplot.axes.BasemapAxes`.
-
+#
 # * `~proplot.axes.CartopyAxes` joins the cartopy
 #   `~cartopy.mpl.geoaxes.GeoAxes` class with the ProPlot
 #   `~matplotlib.axes.Axes` class and adds a `~proplot.axes.GeoAxes.format`
@@ -163,10 +164,11 @@ fig, axs = plot.subplots(
     },
     ncols=2, nrows=5
 )
-axs.format(suptitle='Figure with several projections')
-axs.format(coast=True, latlines=30, lonlines=60)
-axs[:, 1].format(labels=True, lonlines=plot.arange(-180, 179, 60))
-axs[-1, -1].format(labels=True, lonlines=30)
+axs.format(
+    suptitle='Figure with several projections',
+    coast=True, latlines=30, lonlines=60, labels=True,
+)
+axs[-1, :].format(labels=True, lonlines=30)
 axs.format(collabels=['Cartopy projections', 'Basemap projections'])
 plot.rc.reset()
 

--- a/proplot/axes/geo.py
+++ b/proplot/axes/geo.py
@@ -738,13 +738,10 @@ class CartopyAxes(GeoAxes, GeoAxesCartopy):
         # Apply aspect
         self.apply_aspect()
         for gl in self._gridliners:
-            patch = self.background_patch
-            if _version_cartopy <= _version('0.16'):
-                gl._draw_gridliner(background_patch=patch)
-            elif _version_cartopy >= _version('0.18'):
+            if _version_cartopy >= _version('0.18'):
                 gl._draw_gridliner(renderer=renderer)
-            else:  # v0.17
-                gl._draw_gridliner(background_patch=patch, renderer=renderer)
+            else:
+                gl._draw_gridliner(background_patch=self.background_patch)
 
         # Remove gridliners
         if _version_cartopy < _version('0.18'):

--- a/proplot/axes/geo.py
+++ b/proplot/axes/geo.py
@@ -703,17 +703,26 @@ class CartopyAxes(GeoAxes, GeoAxesCartopy):
         ):
             clipped_path = self.background_patch.orig_path.clip_to_bbox(self.viewLim)
             self.background_patch._path = clipped_path
+
+        # Adjust location
+        if _version_cartopy >= _version('0.18'):
+            self.patch._adjust_location()
+
+        # Apply aspect
         self.apply_aspect()
         for gl in self._gridliners:
             patch = self.background_patch
-            try:  # v0.17
+            if _version_cartopy <= _version('0.16'):
+                gl._draw_gridliner(background_patch=patch)
+            elif _version_cartopy >= _version('0.18'):
+                gl._draw_gridliner(renderer=renderer)
+            else:  # v0.17
                 gl._draw_gridliner(background_patch=patch, renderer=renderer)
-            except TypeError:
-                try:  # v0.xx to v0.16
-                    gl._draw_gridliner(background_patch=patch)
-                except TypeError:  # v0.18
-                    gl._draw_gridliner(renderer=renderer)
-        self._gridliners = []
+
+        # Remove gridliners
+        if _version_cartopy < _version('0.18'):
+            self._gridliners = []
+
         return super().get_tightbbox(renderer, *args, **kwargs)
 
     @property

--- a/proplot/axes/geo.py
+++ b/proplot/axes/geo.py
@@ -78,6 +78,9 @@ class GeoAxes(base.Axes):
         latlines=None, latlocator=None, latmax=None,
         lonlines_kw=None, lonlocator_kw=None,
         latlines_kw=None, latlocator_kw=None,
+        lonformatter=None, latformatter=None,
+        lonformatter_kw=None, latformatter_kw=None,
+        rotate_labels=None,
         labels=None, latlabels=None, lonlabels=None,
         patch_kw=None, **kwargs,
     ):
@@ -105,6 +108,25 @@ optional
             Otherwise, should be a `~matplotlib.ticker.Locator` instance.
         lonlocator, latlocator : optional
             Aliases for `lonlines`, `latlines`.
+        lonlines_kw, latlines_kw : dict, optional
+            Keyword argument dictionaries passed to the
+            `~cartopy.mpl.ticker.LongitudeFormatter` and
+            `~cartopy.mpl.ticker.LatitudeFormatter` formatters (respectively) for
+            cartopy axes, or passed to `~mpl_toolkits.basemap.Basemap.drawmeridians`
+            and `~mpl_toolkits.basemap.Basemap.drawparallels` methods (respectively)
+            for basemap axes.
+        lonlocator_kw, latlocator_kw : optional
+            Aliases for `lonlines_kw`, `latlines_kw`.
+        lonformatter, latformatter : `~matplotlib.ticker.Formatter`, optional
+            `~matplotlib.ticker.Formatter` instances used to style longitude
+            and latitude tick labels. For cartopy axes only.
+        lonformatter_kw, latformatter_kw : optional
+            Keyword arguments passed to `~cartopy.mpl.ticker.LongitudeFormatter`
+            and `~cartopy.mpl.ticker.LatitudeFormatter`. Ignored if `lonformatter`
+            or `latformatter` was provided. For cartopy axes only.
+        rotate_labels : bool, optional
+            Whether to rotate longitude and latitude gridline labels. For cartopy
+            axes only. Default is :rc:`geogrid.rotatelabels`.
         latmax : float, optional
             The maximum absolute latitude for meridian gridlines. Default is
             :rc:`geogrid.latmax`.
@@ -172,10 +194,11 @@ optional
             latlines_kw = _not_none(
                 latlines_kw=latlines_kw, latlocator_kw=latlocator_kw, default={},
             )
-            latlines = _not_none(
-                latlines=latlines, latlocator=latlocator,
-                default=rc.get('geogrid.latstep', context=True),
+            rotate_labels = _not_none(
+                rotate_labels, rc.get('geogrid.rotatelabels', context=True)
             )
+            lonformatter_kw = lonformatter_kw or {}
+            latformatter_kw = latformatter_kw or {}
             latmax = _not_none(latmax, rc.get('geogrid.latmax', context=True))
             labels = _not_none(labels, rc.get('geogrid.labels', context=True))
             grid = _not_none(grid, rc.get('geogrid', context=True))
@@ -236,8 +259,12 @@ optional
             self._format_apply(
                 patch_kw=patch_kw,
                 boundinglat=boundinglat, lonlim=lonlim, latlim=latlim,
-                lonlines=lonlines, latlines=latlines, latmax=latmax,
-                lonarray=lonarray, latarray=latarray,
+                lonlines=lonlines, latlines=latlines,
+                lonlines_kw=lonlines_kw, latlines_kw=latlines_kw,
+                lonformatter=lonformatter, latformatter=latformatter,
+                lonformatter_kw=lonformatter_kw, latformatter_kw=latformatter_kw,
+                rotate_labels=rotate_labels,
+                latmax=latmax, lonarray=lonarray, latarray=latarray,
             )
             super().format(**kwargs)
 

--- a/proplot/axes/geo.py
+++ b/proplot/axes/geo.py
@@ -639,7 +639,10 @@ class CartopyAxes(GeoAxes, GeoAxesCartopy):
         self._hide_labels()
         if self.get_autoscale_on() and self.ignore_existing_data_limits:
             self.autoscale_view()
-        if getattr(self.background_patch, 'reclip', None):
+        if (
+            getattr(self.background_patch, 'reclip', None)
+            and hasattr(self.background_patch, 'orig_path')
+        ):
             clipped_path = self.background_patch.orig_path.clip_to_bbox(self.viewLim)
             self.background_patch._path = clipped_path
         self.apply_aspect()

--- a/proplot/axes/geo.py
+++ b/proplot/axes/geo.py
@@ -555,6 +555,9 @@ class CartopyAxes(GeoAxes, GeoAxesCartopy):
             'linestyle': 'geogrid.linestyle',
         }, context=True)
         gl.collection_kwargs.update(kw)
+        pad = rc.get('geogrid.labelpad', context=True)
+        if pad is not None:
+            gl.xpadding = gl.ypadding = pad
 
         # Grid locations
         eps = 1e-10

--- a/proplot/internals/__init__.py
+++ b/proplot/internals/__init__.py
@@ -73,3 +73,31 @@ class _set_state(object):
                 setattr(self._obj, key, self._kwargs_orig[key])
             else:
                 delattr(self._obj, key)
+
+
+class _version(list):
+    """
+    Casual version parser for MAJOR.MINOR version strings. Do not want to add
+    'packaging' dependency and only care about major and minor tags.
+    """
+    def __repr__(self):
+        return f'version({self._version})'
+
+    def __init__(self, version):
+        try:
+            major, minor, *_ = version.split('.')
+            major, minor = int(major), int(minor)
+        except (ValueError, AttributeError):
+            raise ValueError(f'Invalid version {version!r}.')
+        self._version = version
+        super().__init__((major, minor))  # then use builtin python list sorting
+
+
+# Add matplotlib and cartopy versions
+import matplotlib as _
+_version_mpl = _version(_.__version__)
+try:
+    import cartopy as _
+    _version_cartopy = _version(_.__version__)
+except ImportError:
+    _version_cartopy = (0, 0)

--- a/proplot/internals/defaults.py
+++ b/proplot/internals/defaults.py
@@ -95,6 +95,7 @@ _rc_added_default = {
     'geoaxes.linewidth': None,  # = linewidth
     'geogrid.alpha': 0.5,
     'geogrid.color': 'k',
+    'geogrid.labelpad': 5,  # use cartopy default
     'geogrid.labels': False,
     'geogrid.labelsize': None,  # = small
     'geogrid.latmax': 90,
@@ -102,6 +103,7 @@ _rc_added_default = {
     'geogrid.linestyle': ':',
     'geogrid.linewidth': 1.0,
     'geogrid.lonstep': 30,
+    'geogrid.rotatelabels': True,  # False limits projections where labels are available
     'gridminor.alpha': None,  # = grid.alpha
     'gridminor.color': None,  # = grid.color
     'gridminor.linestyle': None,  # = grid.linewidth

--- a/proplot/scale.py
+++ b/proplot/scale.py
@@ -10,7 +10,7 @@ import matplotlib.transforms as mtransforms
 import matplotlib.ticker as mticker
 from . import ticker as pticker
 from .internals import ic  # noqa: F401
-from .internals import warnings, _not_none
+from .internals import warnings, _version, _version_mpl, _not_none
 scales = mscale._scale_mapping
 
 __all__ = [
@@ -33,11 +33,9 @@ def _parse_logscale_args(*keys, **kwargs):
     change the default `linthresh` to ``1``.
     """
     # NOTE: Scale classes ignore unused arguments with warnings, but matplotlib 3.3
-    # version changes the keyword args. Since we can't do a try except clause, only way
-    # to avoid warnings with 3.3 upgrade is to test version string. Ugly, I know.
-    from packaging import version
-    from matplotlib import __version__
-    kwsuffix = '' if version.parse(__version__) >= version.parse('3.3') else 'x'
+    # version changes the keyword args. Since we can't do a try except clause, only
+    # way to avoid warnings with 3.3 upgrade is to test version string.
+    kwsuffix = '' if _version_mpl >= _version('3.3') else 'x'
     for key in keys:
         # Remove duplicates
         opts = {

--- a/proplot/wrappers.py
+++ b/proplot/wrappers.py
@@ -208,10 +208,11 @@ def default_crs(self, func, *args, crs=None, **kwargs):
             raise err
         args, crs = args[:-1], args[-1]
         result = func(self, *args, crs=crs, **kwargs)
+
     # Fix extent, so axes tight bounding box gets correct box!
     # From this issue:
     # https://github.com/SciTools/cartopy/issues/1207#issuecomment-439975083
-    if name == 'set_extent':
+    if name == 'set_extent' and hasattr(self.outline_patch, 'orig_path'):
         clipped_path = self.outline_patch.orig_path.clip_to_bbox(self.viewLim)
         self.outline_patch._path = clipped_path
         self.background_patch._path = clipped_path

--- a/proplot/wrappers.py
+++ b/proplot/wrappers.py
@@ -26,7 +26,7 @@ from . import colors as pcolors
 from .config import rc
 from .utils import edges, edges2d, units, to_xyz, to_rgb
 from .internals import ic  # noqa: F401
-from .internals import docstring, warnings, _not_none
+from .internals import docstring, warnings, _version, _version_cartopy, _not_none
 try:
     from cartopy.crs import PlateCarree
 except ModuleNotFoundError:
@@ -209,13 +209,13 @@ def default_crs(self, func, *args, crs=None, **kwargs):
         args, crs = args[:-1], args[-1]
         result = func(self, *args, crs=crs, **kwargs)
 
-    # Fix extent, so axes tight bounding box gets correct box!
-    # From this issue:
+    # Fix extent, so axes tight bounding box gets correct box! From this issue:
     # https://github.com/SciTools/cartopy/issues/1207#issuecomment-439975083
-    if name == 'set_extent' and hasattr(self.outline_patch, 'orig_path'):
-        clipped_path = self.outline_patch.orig_path.clip_to_bbox(self.viewLim)
-        self.outline_patch._path = clipped_path
-        self.background_patch._path = clipped_path
+    if _version_cartopy < _version('0.18'):
+        if name == 'set_extent':
+            clipped_path = self.outline_patch.orig_path.clip_to_bbox(self.viewLim)
+            self.outline_patch._path = clipped_path
+            self.background_patch._path = clipped_path
     return result
 
 


### PR DESCRIPTION
Resolves #21 and resolves #148. This PR will add support for cartopy 0.18. Some attribute names were deprecated that proplot uses internally, several bugs were fixed (so proplot's bug fix monkey patches are no longer necessary), and a new bug was introduced that required a new bug fix monkey patch.

This PR offers support for cartopy's `LongitudeFormatter` and `LatitudeFormatter` formatters, and uses `LongitudeLocator` and `LatitudeLocator` to determine longitude and latitude gridline locations by default, unless the user specifies some custom gridline interval/gridline locations. It also adds `rc['geogrid.rotatelabels']` and `rc['geogrid.labelpad']` rc settings.