### PR TITLE
Add "properties" to all matplotlib artists

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -115,6 +115,15 @@ Gridspec classes
    :toctree: api
 
 
+Artist subclass
+===============
+
+.. automodule:: proplot.artist
+
+.. automodsumm:: proplot.artist
+   :toctree: api
+
+
 Miscellaneous tools
 ===================
 

--- a/proplot/__init__.py
+++ b/proplot/__init__.py
@@ -19,6 +19,7 @@ with timers._benchmark('imports'):
     from .figure import *  # noqa: F401 F403
     from .ui import *  # noqa: F401 F403
     from .demos import *  # noqa: F401 F403
+    from .artist import *  # noqa: F401 F403
 
 # SCM versioning
 name = 'proplot'

--- a/proplot/artist.py
+++ b/proplot/artist.py
@@ -3,7 +3,6 @@
 Create a metaclass
 """
 import matplotlib.artist as martist
-import matplotlib.lines as mlines
 
 __all__ = []
 
@@ -46,67 +45,7 @@ def _gen_properties(cls):
             yield name, property(*args, doc=getter.__doc__)
 
 
-# Approach #1: Apply properties to all artists
 for cls in _gen_subclasses(martist.Artist):
     for name, prop in _gen_properties(cls):
         setattr(cls, name, prop)
     print(f'Added properties to {cls.__name__}.')
-
-
-# Approach #2: Requires importing proplot before matplotlib.
-# This will not work for ProPlot but may be in matplotlib's future.
-class Propertifier(type):  # create new class definitions
-    """
-    Artist metaclass.
-    """
-    def __init__(cls, *args, **kwargs):
-        """
-        Add property getters and setters to all matplotlib artist subclasses.
-        """
-        super().__init__(*args, **kwargs)
-        for name, property in _gen_properties(cls):
-            setattr(cls, name, property)
-        print(f'Added properties to {cls.__name__}.')
-
-
-class Artist(martist.Artist, metaclass=Propertifier):
-    """
-    New base class for all matplotlib artists that
-    uses `Propertifier` as the metaclass.
-    """
-
-
-# Apply monkey patch
-import matplotlib.artist as martist
-martist.Artist = Artist
-
-
-# Testing metaclasses
-class MetaClass(type):
-    def __init__(cls, *args, **kwargs):
-        print('Brand new class!', cls)
-        super().__init__(*args, **kwargs)
-
-
-A = MetaClass('A', (object,), {})
-B = MetaClass('B', (A,), {})
-
-
-# Testing Artist
-class Test(Artist):
-    def set_foo(self, foo):
-        print('set foo!', foo)
-
-    def get_foo(self):
-        print('get foo!')
-
-    def get_bar(self):
-        print('get bar!')
-
-
-class Line2D(Artist, mlines.Line2D):
-    pass
-
-
-test = Test()
-line = Line2D([0], [0])

--- a/proplot/artist.py
+++ b/proplot/artist.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""
+Create a metaclass
+"""
+import matplotlib.artist as martist
+import matplotlib.lines as mlines
+
+__all__ = []
+
+PROPS_PROTECTED = [
+    'figure', 'axes', 'pickradius',
+]
+
+
+def _gen_subclasses(cls):
+    """
+    Generate all of a class's sublcasses with recursion.
+    """
+    try:
+        for subclass in cls.__subclasses__():
+            yield subclass
+            for subclass in _gen_subclasses(subclass):
+                yield subclass
+    except TypeError:
+        return
+
+
+def _gen_properties(cls):
+    """
+    Generate property definitions for every
+    Get proper
+    """
+    for attr in dir(cls):
+        obj = getattr(cls, attr)
+        if callable(obj) and attr[:4] == 'get_':
+            getter = obj
+            name = attr[4:]
+            if hasattr(cls, name):
+                continue
+            elif name in PROPS_PROTECTED:
+                continue
+            args = [getter]  # property args
+            setter = getattr(cls, 'set_' + name, None)
+            if callable(setter):
+                args.append(setter)
+            yield name, property(*args, doc=getter.__doc__)
+
+
+# Approach #1: Apply properties to all artists
+for cls in _gen_subclasses(martist.Artist):
+    for name, prop in _gen_properties(cls):
+        setattr(cls, name, prop)
+    print(f'Added properties to {cls.__name__}.')
+
+
+# Approach #2: Requires importing proplot before matplotlib.
+# This will not work for ProPlot but may be in matplotlib's future.
+class Propertifier(type):  # create new class definitions
+    """
+    Artist metaclass.
+    """
+    def __init__(cls, *args, **kwargs):
+        """
+        Add property getters and setters to all matplotlib artist subclasses.
+        """
+        super().__init__(*args, **kwargs)
+        for name, property in _gen_properties(cls):
+            setattr(cls, name, property)
+        print(f'Added properties to {cls.__name__}.')
+
+
+class Artist(martist.Artist, metaclass=Propertifier):
+    """
+    New base class for all matplotlib artists that
+    uses `Propertifier` as the metaclass.
+    """
+
+
+# Apply monkey patch
+import matplotlib.artist as martist
+martist.Artist = Artist
+
+
+# Testing metaclasses
+class MetaClass(type):
+    def __init__(cls, *args, **kwargs):
+        print('Brand new class!', cls)
+        super().__init__(*args, **kwargs)
+
+
+A = MetaClass('A', (object,), {})
+B = MetaClass('B', (A,), {})
+
+
+# Testing Artist
+class Test(Artist):
+    def set_foo(self, foo):
+        print('set foo!', foo)
+
+    def get_foo(self):
+        print('get foo!')
+
+    def get_bar(self):
+        print('get bar!')
+
+
+class Line2D(Artist, mlines.Line2D):
+    pass
+
+
+test = Test()
+line = Line2D([0], [0])


### PR DESCRIPTION
This PR is related to #89 and  adds `@property` setters and getters to every single `Artist` subclass. The core logic for this turns out to be surprisingly simple. After this PR is merged proplot users will be able to use the much cleaner, more object-oriented "dot" syntax for changing matplotlib artist attributes:

```python
# Original API
fig, ax = pyplot.subplots()
ax.set_title('Title')
ax.set_xlabel('xlabel')
ax.set_xticks([1, 2, 3])
h, = ax.plot(...)
h.set_color('red')
h.set_linewidth(1)


# ProPlot API if this is merged
fig, ax = proplot.subplots()
ax.format(title='Title', xlabel='xlabel', xticks=[1, 2, 3])  # with bulk setter
ax.title = 'Title'  # with individual setters
ax.xlabel = 'xlabel'
ax.xticks = [1, 2, 3]
h, = ax.plot(...)
h.color = 'red'
h.linewidth = 1
``` 

I am not sure about the side-effects of this -- the problem is this breaks classes that use instance-level attributes with the same names as the setters and getters (e.g. if an artist subclass both the getter `get_linewidth()` and the literal attribute `linewidth`), and the only way to address this is to go through the source code class-by-class and make explicit exceptions (which is quite fragile, since the attributes may change from version-to-version). Monkey patching is not possible because you [cannot add properties](https://stackoverflow.com/a/1355444/4970632) as instance-level attributes.

This is a really neat PR, but it will require a lot of testing and it's not as high priority as some other PRs. So it may be quite a while before this is merged.