### PR TITLE
Permit setting opacity gradations with Colormap.set_alpha and add new to_rgba functions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -141,6 +141,14 @@ There are quite a lot of deprecations for this release.
 - No longer distinguish between "quick" settings and proplot's "added"
   settings (:commit:`e6dd8314`). Quick settings, added settings, and matplotlib
   settings can all have "children" so the distinction no longer makes sense.
+- Add opacity-preserving functions `~proplot.utils.to_rgba`
+  and `~proplot.utils.to_xyza`, plus `~proplot.utils.set_alpha` for
+  changing alpha channel of arbitrary color (:commit:`81c647da`).
+- Add to `~proplot.colors.LinearSegmentedColormap.set_alpha` the ability to
+  create an *opacity gradation*, rather than just an opacity for the entire
+  colormap (:commit:`4a138ba4`).
+- Support passing colormap objects, not just names, to `~proplot.demos.show_cmaps`
+  and `~proplot.demos.show_cycles` (:commit:`7f8ca59f`).
 - Add options to `~proplot.axes.plot.indicate_error` for adding *shading*
   to arbitrary plots (:pr:`166`, :commit:`d8c50a8d`). Also support automatic legend
   entries for shading and ensure `indicate_error` preserves metadata.

--- a/docs/basics.py
+++ b/docs/basics.py
@@ -53,6 +53,7 @@
 # That is, the default display background is gray, the default background for
 # saved figures is transparent, and the default background is white when you pass
 # ``transparent=False`` to `~matplotlib.figure.Figure.savefig`.
+#
 # ProPlot also sets the default :rcraw:`savefig.format` to PDF, because
 # (1) vector graphic formats are always more suitable for matplotlib figures than
 # raster formats, (2) most academic journals these days accept PDF format figures

--- a/docs/projections.py
+++ b/docs/projections.py
@@ -359,7 +359,9 @@ axs[0].format(
     title='Cartopy example', land=True,
     lonlim=(-20, 50), latlim=(30, 70)
 )
-axs[1].format(title='Basemap example', land=True)
+axs[1].format(
+    title='Basemap example', land=True, lonlines=20
+)
 plot.rc.reset()
 
 

--- a/proplot/constructor.py
+++ b/proplot/constructor.py
@@ -27,7 +27,7 @@ from . import colors as pcolors
 from . import ticker as pticker
 from . import scale as pscale
 from .config import rc
-from .utils import to_rgb
+from .utils import to_rgba
 from .internals import ic  # noqa: F401
 from .internals import warnings, _version, _version_cartopy, _version_mpl, _not_none
 try:
@@ -555,7 +555,7 @@ def Colormap(
             not isinstance(arg, str) and np.iterable(arg)
             and all(np.iterable(color) for color in arg)
         ):
-            colors = [to_rgb(color, cycle=cycle, alpha=True) for color in arg]
+            colors = [to_rgba(color, cycle=cycle) for color in arg]
             if listmode == 'listed':
                 cmap = pcolors.ListedColormap(colors, tmp)
             elif listmode == 'linear':
@@ -569,7 +569,7 @@ def Colormap(
             if creverse:
                 arg = arg[:-2]
             try:
-                color = to_rgb(arg, cycle=cycle, alpha=True)
+                color = to_rgba(arg, cycle=cycle)
             except (ValueError, TypeError):
                 message = f'Invalid colormap, color cycle, or color {arg!r}.'
                 if isinstance(arg, str) and arg[:1] != '#':


### PR DESCRIPTION
This permits passing non-scalar values to `LinearSegmentedColormap.set_alpha` and adds `to_rgba` and `to_xyza` to go along with `to_rgb` and `to_xyz`.