### PR TITLE
Tight layout options

### DIFF
--- a/proplot/gridspec.py
+++ b/proplot/gridspec.py
@@ -90,6 +90,7 @@ def _calc_geometry(**kwargs):
     wratios, hratios = kwargs['wratios'], kwargs['hratios']
     left, bottom = kwargs['left'], kwargs['bottom']
     right, top = kwargs['right'], kwargs['top']
+    wequal, hequal, equal = kwargs['wequal'], kwargs['hequal'], kwargs['equal']
 
     # Panel string toggles, lists containing empty strings '' (indicating a
     # main axes), or one of 'l', 'r', 'b', 't' (indicating axes panels) or
@@ -249,6 +250,14 @@ def _calc_geometry(**kwargs):
     bottom = bottom / height
     right = 1 - right / width
     top = 1 - top / height
+
+    # Constant spacing corrections
+    if equal:  # do both
+        wequal = hequal = True
+    if wequal:
+        wspace = [max(wspace) for _ in wspace]
+    if hequal:
+        hspace = [max(hspace) for _ in hspace]
 
     # Return gridspec keyword args
     gridspec_kw = {

--- a/proplot/ui.py
+++ b/proplot/ui.py
@@ -202,6 +202,7 @@ def subplots(
     hspace=None, wspace=None, space=None,
     hratios=None, wratios=None,
     width_ratios=None, height_ratios=None,
+    wequal=None, hequal=None, equal=None,
     left=None, bottom=None, right=None, top=None,
     basemap=None, proj=None, projection=None,
     proj_kw=None, projection_kw=None,
@@ -269,6 +270,10 @@ def subplots(
         Units are interpreted by `~proplot.utils.units` for each element of
         the list. By default, these are determined by the "tight
         layout" algorithm.
+    wequal, hequal, equal :  bool, optional
+        Whether to automatically make spacing between columns, rows, or both
+        equal.
+        Default false.
     left, right, top, bottom : float or str, optional
         Passed to `~proplot.gridspec.GridSpec`, denotes the width of padding
         between the subplots and the figure edge. Units are interpreted by
@@ -541,6 +546,7 @@ list thereof, or dict thereof, optional
         left=left, right=right, bottom=bottom, top=top,
         width=width, height=height, axwidth=axwidth, axheight=axheight,
         wratios=wratios, hratios=hratios, wspace=wspace, hspace=hspace,
+        wequal=bool(wequal), hequal=bool(hequal), equal=bool(equal),
         wpanels=[''] * ncols, hpanels=[''] * nrows,
     )
     fig = plt.figure(

--- a/proplot/ui.py
+++ b/proplot/ui.py
@@ -272,8 +272,7 @@ def subplots(
         layout" algorithm.
     wequal, hequal, equal :  bool, optional
         Whether to automatically make spacing between columns, rows, or both
-        equal.
-        Default false.
+        equal. Default is ``False``.
     left, right, top, bottom : float or str, optional
         Passed to `~proplot.gridspec.GridSpec`, denotes the width of padding
         between the subplots and the figure edge. Units are interpreted by


### PR DESCRIPTION
This would add the feature of https://github.com/lukelbd/proplot/issues/64, the ability to set `hspace` between all rows, `wspace` between all columns, or both, based on the calculated maximum value in ProPlot's layout routine.

I am not sure if this follows what you were suggesting in [this comment](https://github.com/lukelbd/proplot/issues/64#issue-522492491). It seems to work, but the gridspec's idea of `hspace` and `wspace` don't seem to match how the figure shows up (see my example, maybe I am printing the wrong thing).

See in action [here](https://gist.github.com/zmoon92/3da69fc1754cc6faddd523497d363828).