### PR TITLE
Support color lists for boxplots and violins

### DIFF
--- a/proplot/axes/plot.py
+++ b/proplot/axes/plot.py
@@ -2015,14 +2015,14 @@ color-spec, optional
 
         # If fillcolor is a list, make a list
         if not isinstance(fillcolor, list):
-            fillcolor = [fillcolor]*len(artists)
+            fillcolor = [fillcolor] * len(artists)
 
         for i, artist in enumerate(artists):
             if icolor is not None:
                 if isinstance(icolor, list):
                     if key in ['caps', 'whiskers']:
-                        artist.set_color(icolor[i//2])
-                        artist.set_markeredgecolor(icolor[i//2])
+                        artist.set_color(icolor[i // 2])
+                        artist.set_markeredgecolor(icolor[i // 2])
                     else:
                         artist.set_color(icolor[i])
                         artist.set_markeredgecolor(icolor[i])
@@ -2126,9 +2126,9 @@ def violinplot_wrapper(
 
     # If the color settings are a list, make a list
     if not isinstance(edgecolor, list):
-        edgecolor = [edgecolor]*len(artists)
+        edgecolor = [edgecolor] * len(artists)
     if not isinstance(fillcolor, list):
-        fillcolor = [fillcolor]*len(artists)
+        fillcolor = [fillcolor] * len(artists)
 
     for i, artist in enumerate(artists):
         artist.set_alpha(fillalpha)

--- a/proplot/axes/plot.py
+++ b/proplot/axes/plot.py
@@ -1946,13 +1946,14 @@ def boxplot_wrapper(
     ----------
     *args : 1D or 2D ndarray
         The data array.
-    color : color-spec, optional
-        The color (or color list) of all objects.
+    color : color-spec, list, optional
+        The color of all objects. If a list, it should be the same length as
+        the number of objects.
     fill : bool, optional
         Whether to fill the box with a color.
-    fillcolor : color-spec, optional
-        The fill color (or color list) for the boxes. Default is the next
-        color cycler color.
+    fillcolor : color-spec, list, optional
+        The fill color for the boxes. Default is the next color cycler color. If
+        a list, it should be the same length as the number of objects.
     fillalpha : float, optional
         The opacity of the boxes. Default is ``1``.
     lw, linewidth : float, optional
@@ -1966,9 +1967,10 @@ def boxplot_wrapper(
     markersize : float, optional
         Marker size for the 'fliers', i.e. outliers.
     boxcolor, capcolor, meancolor, mediancolor, whiskercolor : \
-color-spec, optional
-        The color (or color list) of various boxplot components. These are
-        shorthands so you don't have to pass e.g. a ``boxprops`` dictionary.
+color-spec, list, optional
+        The color of various boxplot components. If a list, it should be the
+        same length as the number of objects. These are shorthands so you don't
+        have to pass e.g. a ``boxprops`` dictionary.
     boxlw, caplw, meanlw, medianlw, whiskerlw : float, optional
         The line width of various boxplot components. These are shorthands so
         you don't have to pass e.g. a ``boxprops`` dictionary.
@@ -2013,7 +2015,7 @@ color-spec, optional
         ilw = _not_none(ilw, lw)
         icolor = _not_none(icolor, color)
 
-        # If fillcolor is a list, make a list
+        # If fillcolor is a not list, make a list
         if not isinstance(fillcolor, list):
             fillcolor = [fillcolor] * len(artists)
 
@@ -2069,12 +2071,12 @@ def violinplot_wrapper(
         The data array.
     lw, linewidth : float, optional
         The linewidth of the line objects. Default is ``1``.
-    edgecolor : color-spec, optional
-        The edge color (or color list) for the violin patches. Default is
-        ``'black'``.
-    fillcolor : color-spec, optional
-        The violin plot fill color (or color list). Default is the next
-        color cycler color.
+    edgecolor : color-spec, list, optional
+        The edge color for the violin patches. Default is ``'black'``. If a
+        list, it should be the same length as the number of objects.
+    fillcolor : color-spec, list, optional
+        The violin plot fill color. Default is the next color cycler color. If
+        a list, it should be the same length as the number of objects.
     fillalpha : float, optional
         The opacity of the violins. Default is ``1``.
     vert : bool, optional
@@ -2124,7 +2126,7 @@ def violinplot_wrapper(
 
     artists = obj['bodies']
 
-    # If the color settings are a list, make a list
+    # If the color settings are not a list, make a list
     if not isinstance(edgecolor, list):
         edgecolor = [edgecolor] * len(artists)
     if not isinstance(fillcolor, list):

--- a/proplot/axes/plot.py
+++ b/proplot/axes/plot.py
@@ -1947,11 +1947,12 @@ def boxplot_wrapper(
     *args : 1D or 2D ndarray
         The data array.
     color : color-spec, optional
-        The color of all objects.
+        The color (or color list) of all objects.
     fill : bool, optional
         Whether to fill the box with a color.
     fillcolor : color-spec, optional
-        The fill color for the boxes. Default is the next color cycler color.
+        The fill color (or color list) for the boxes. Default is the next
+        color cycler color.
     fillalpha : float, optional
         The opacity of the boxes. Default is ``1``.
     lw, linewidth : float, optional
@@ -1966,8 +1967,8 @@ def boxplot_wrapper(
         Marker size for the 'fliers', i.e. outliers.
     boxcolor, capcolor, meancolor, mediancolor, whiskercolor : \
 color-spec, optional
-        The color of various boxplot components. These are shorthands so you
-        don't have to pass e.g. a ``boxprops`` dictionary.
+        The color (or color list) of various boxplot components. These are
+        shorthands so you don't have to pass e.g. a ``boxprops`` dictionary.
     boxlw, caplw, meanlw, medianlw, whiskerlw : float, optional
         The line width of various boxplot components. These are shorthands so
         you don't have to pass e.g. a ``boxprops`` dictionary.
@@ -2011,16 +2012,29 @@ color-spec, optional
         artists = obj[key]
         ilw = _not_none(ilw, lw)
         icolor = _not_none(icolor, color)
-        for artist in artists:
+
+        # If fillcolor is a list, make a list
+        if not isinstance(fillcolor, list):
+            fillcolor = [fillcolor]*len(artists)
+
+        for i, artist in enumerate(artists):
             if icolor is not None:
-                artist.set_color(icolor)
-                artist.set_markeredgecolor(icolor)
+                if isinstance(icolor, list):
+                    if key in ['caps', 'whiskers']:
+                        artist.set_color(icolor[i//2])
+                        artist.set_markeredgecolor(icolor[i//2])
+                    else:
+                        artist.set_color(icolor[i])
+                        artist.set_markeredgecolor(icolor[i])
+                else:
+                    artist.set_color(icolor)
+                    artist.set_markeredgecolor(icolor)
             if ilw is not None:
                 artist.set_linewidth(ilw)
                 artist.set_markeredgewidth(ilw)
             if key == 'boxes' and fill:
                 patch = mpatches.PathPatch(
-                    artist.get_path(), color=fillcolor,
+                    artist.get_path(), color=fillcolor[i],
                     alpha=fillalpha, linewidth=0)
                 self.add_artist(patch)
             if key == 'fliers':
@@ -2056,9 +2070,11 @@ def violinplot_wrapper(
     lw, linewidth : float, optional
         The linewidth of the line objects. Default is ``1``.
     edgecolor : color-spec, optional
-        The edge color for the violin patches. Default is ``'black'``.
+        The edge color (or color list) for the violin patches. Default is
+        ``'black'``.
     fillcolor : color-spec, optional
-        The violin plot fill color. Default is the next color cycler color.
+        The violin plot fill color (or color list). Default is the next
+        color cycler color.
     fillalpha : float, optional
         The opacity of the violins. Default is ``1``.
     vert : bool, optional
@@ -2105,12 +2121,21 @@ def violinplot_wrapper(
     # Modify body settings
     if isinstance(result, (list, tuple)):
         obj = result[0]
-    for artist in obj['bodies']:
+
+    artists = obj['bodies']
+
+    # If the color settings are a list, make a list
+    if not isinstance(edgecolor, list):
+        edgecolor = [edgecolor]*len(artists)
+    if not isinstance(fillcolor, list):
+        fillcolor = [fillcolor]*len(artists)
+
+    for i, artist in enumerate(artists):
         artist.set_alpha(fillalpha)
-        artist.set_edgecolor(edgecolor)
+        artist.set_edgecolor(edgecolor[i])
         artist.set_linewidths(lw)
         if fillcolor is not None:
-            artist.set_facecolor(fillcolor)
+            artist.set_facecolor(fillcolor[i])
     return result
 
 


### PR DESCRIPTION
I've just tried to add the feature I was talking about in https://github.com/lukelbd/proplot/issues/217, here is an adaptation of the example from https://proplot.readthedocs.io/en/latest/1dplots.html#Box-plots-and-violin-plots:

```python
import proplot as plot
import numpy as np
import pandas as pd

# Generate sample data
N = 500
state = np.random.RandomState(51423)
data = state.normal(size=(N, 5)) + 2 * (state.rand(N, 5) - 0.5) * np.arange(5)
data = pd.DataFrame(
    data,
    columns=pd.Index(['a', 'b', 'c', 'd', 'e'], name='xlabel')
)

# Generate figure
fig, axs = plot.subplots(ncols=2, axwidth=2.5)
axs.format(grid=False, suptitle='Boxes and violins demo')

# Box plots
colors = ['gray5', 'pink5', 'violet5', 'blue5', 'teal5']
ax = axs[0]
obj1 = ax.boxplot(
    data, lw=0.7, marker='x', fillcolor=colors, medianlw=1, mediancolor=colors, 
    whiskercolor=colors, capcolor=colors, fliercolor=colors, boxcolor=colors
)
ax.format(title='Box plots', titleloc='uc')

# Violin plots
ax = axs[1]
obj2 = ax.violinplot(
    data, lw=0.7, fillcolor=colors, edgecolor=colors,
    points=500, bw_method=0.3, means=True
)

ax.format(title='Violin plots', titleloc='uc')

fig.save('boxes_violins_demo.jpg', dpi=300)
```

![boxes_violins_demo](https://user-images.githubusercontent.com/20254164/90148781-06ef7780-dd84-11ea-858b-aff8d304139f.jpg)

From what I tried it works with and without a list, it is also possible to change all the colors for boxplots with a list for the `color` argument as before. I don't know how to modify more the violins plots, I let you see already this @lukelbd!