### PR TITLE
Add feature: urban areas in ax.format(urban=True) #230

### DIFF
--- a/proplot/axes/geo.py
+++ b/proplot/axes/geo.py
@@ -412,14 +412,14 @@ optional
             *For cartopy axes only.*
             The number of interpolation steps used to draw gridlines.
             Default is :rc:`grid.nsteps`.
-        land, ocean, coast, rivers, lakes, borders, innerborders : bool, \
+        land, ocean, coast, rivers, lakes, borders, innerborders, urban : bool, \
 optional
             Toggles various geographic features. These are actually the
             :rcraw:`land`, :rcraw:`ocean`, :rcraw:`coast`, :rcraw:`rivers`,
-            :rcraw:`lakes`, :rcraw:`borders`, and :rcraw:`innerborders`
+            :rcraw:`lakes`, :rcraw:`borders`, :rcraw:`innerborders`, and :rcraw:`urban`,
             settings passed to `~proplot.config.RcConfigurator.context`.
             The style can be modified using additional `rc` settings.
-
+            (Urban works only with reso='med' or 'hi')
             For example, to change :rcraw:`land.color`, use
             ``ax.format(landcolor='green')``, and to change :rcraw:`land.zorder`,
             use ``ax.format(landzorder=4)``.
@@ -970,7 +970,7 @@ class CartopyAxes(GeoAxes, GeoAxesBase):
             # See: https://github.com/SciTools/cartopy/issues/803
             if feat is not None:
                 kw = rc.category(name, context=drawn)
-                if name in ('coast', 'rivers', 'borders', 'innerborders'):
+                if name in ('coast', 'rivers', 'borders', 'innerborders', 'urban'):
                     kw.update({'edgecolor': kw.pop('color'), 'facecolor': 'none'})
                 else:
                     kw.update({'linewidth': 0})

--- a/proplot/config.py
+++ b/proplot/config.py
@@ -1154,7 +1154,11 @@ def _get_style_dicts(style, infer=False, filter=True):
     # Always apply the default style *first* so styles are rigid
     kw_matplotlib = _get_default_dict()
     if style == 'default' or style is mpl.rcParamsDefault:
-        return kw_matplotlib
+        if infer:
+            kw_proplot = _infer_added_params(kw_matplotlib)
+            return kw_matplotlib, kw_proplot
+        else:
+            return kw_matplotlib
 
     # Apply "pseudo" default properties. Pretend some proplot settings are part of
     # the matplotlib specification so they propagate to other styles.

--- a/proplot/constructor.py
+++ b/proplot/constructor.py
@@ -320,6 +320,7 @@ CARTOPY_FEATURES = {  # positional arguments passed to NaturalEarthFeature
     'rivers': ('physical', 'rivers_lake_centerlines'),
     'borders': ('cultural', 'admin_0_boundary_lines_land'),
     'innerborders': ('cultural', 'admin_1_states_provinces_lakes'),
+    'urban': ('cultural', 'urban_areas')
 }
 BASEMAP_FEATURES = {  # names of relevant basemap methods
     'land': 'fillcontinents',

--- a/proplot/internals/rcsetup.py
+++ b/proplot/internals/rcsetup.py
@@ -627,6 +627,24 @@ _rc_proplot = {
         'Z-order for land patches.'
     ),
 
+    # Urban patches
+    'urban': (
+        False,
+        'Boolean, toggles urban patches on and off.'
+    ),
+    'urban.color': (
+        'black',
+        'Face color for urban patches.'
+    ),
+    'urban.linewidth': (
+        LINEWIDTH,
+        'Line width for urban borders.'
+    ),
+    'urban.zorder': (
+        ZLINES,
+        'Z-order for urban patches.'
+    ),
+
     # Left subplot labels
     'leftlabel.color': (
         'black',
@@ -686,7 +704,7 @@ _rc_proplot = {
 
     # Geographic resolution
     'reso': (
-        'lo',
+        'med',
         'Resolution for `~proplot.axes.GeoAxes` geographic features. '
         "Must be one of ``'lo'``, ``'med'``, ``'hi'``, ``'x-hi'``, or ``'xx-hi'``."
     ),


### PR DESCRIPTION
Adding a new feature `urban=True` for urban areas. Changed default reso to 'med'. 