### PR TITLE
Return default savefig transparency to False

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -69,6 +69,9 @@ ProPlot v0.7.0 (2021-06-30)
 
 .. rubric:: Deprecated
 
+* Change default :rcraw:`savefig.transparent` back to ``False`` (:pr:`252`). Dubious
+  justification for ``True`` in the first place, and makes default PNG proplot figures
+  unreadable wherever "dark mode" is enabled.
 * Rename `SciVisColor` colormaps from ``Blue1``, ``Blue2``, etc. to plurals ``Blues1``,
   ``Blues2``, etc. to avoid name conflict with open-color colors. This permits making
   monochromatic open-color maps with e.g. ``plot.Colormap('blue9')``, and feels more

--- a/docs/basics.py
+++ b/docs/basics.py
@@ -55,11 +55,8 @@
 #    `matplotlib backend <https://matplotlib.org/faq/usage_faq#what-is-a-backend>`__
 #    -- the default background color is white when the figure is saved. This is done
 #    by setting :rcraw:`figure.facecolor` to gray, in order to improve contrast
-#    when working with figures.
-#    ProPlot also makes the default saved figure background *transparent*
-#    by setting :rcraw:`savefig.transparent` to ``True``
-#    and changes the default :rcraw:`savefig.format` from PNG to PDF
-#    for the following reasons:
+#    when working with figures, similar to MATLAB. ProPlot also changes the default
+#    :rcraw:`savefig.format` from PNG to PDF for the following reasons:
 #
 #        #. Vector graphic formats are infinitely scalable.
 #        #. Vector graphic formats are preferred by academic journals.

--- a/docs/projections.py
+++ b/docs/projections.py
@@ -142,7 +142,7 @@ axs[2].format(
 #
 #    * ProPlot ensures that polar cartopy projections like
 #      `~cartopy.crs.NorthPolarStereo` have circular boundaries (see `this example\
-#      <https://scitools.org.uk/cartopy/docs/latest/gallery/always_circular_stereo>`__
+#      <https://scitools.org.uk/cartopy/docs/latest/gallery/lines_and_polygons/always_circular_stereo.html>`__
 #      from the cartopy website).
 #    * By default, non-polar cartopy projections are forced to have global extent
 #      with `~cartopy.mpl.geoaxes.GeoAxes.set_global` and polar cartopy projections

--- a/proplot/figure.py
+++ b/proplot/figure.py
@@ -1262,7 +1262,7 @@ class Figure(mfigure.Figure):
         return self.savefig(filename, **kwargs)
 
     def savefig(self, filename, **kwargs):
-        # Automatically expand user the user name. Undocumented because we
+        # Automatically expand the user name. Undocumented because we
         # do not want to overwrite the matplotlib docstring.
         # TODO: Concatenate docstrings.
         if isinstance(filename, str):

--- a/proplot/internals/rcsetup.py
+++ b/proplot/internals/rcsetup.py
@@ -208,7 +208,7 @@ _rc_matplotlib_default = {
     'savefig.dpi': 1200,  # academic journal recommendations for raster line art
     'savefig.facecolor': 'white',  # different from figure.facecolor
     'savefig.format': 'pdf',  # most users use bitmap, but vector graphics are better
-    'savefig.transparent': True,
+    'savefig.transparent': False,
     'xtick.direction': TICKDIR,
     'xtick.labelsize': LABELSIZE,
     'xtick.major.pad': TICKPAD,


### PR DESCRIPTION
Originally I enforced the default behavior `rc['savefig.transparent'] = True` to make saved figure backgrounds transparent by default. This can be nice when putting plots on slides, posters, or websites with different light-colored backgrounds.

However, with the rising popularity of "dark modes" (on Github, macOS, twitter, etc.), this behavior more often results in users trying to read black text on dark backgrounds, and can be extremely frustrating and confusing. It also results in saved PDFs (which always show against white backgrounds) looking different from saved PNGs.

This PR reverts proplot to the more sensible default behavior of `rc['savefig.transparent'] = False`.