### PR TITLE
Final improvements to 1D plotting wrappers

### DIFF
--- a/WHATSNEW.rst
+++ b/WHATSNEW.rst
@@ -112,8 +112,8 @@ ProPlot v0.7.0 (2021-07-##)
 * When using ``medians=True`` or ``means=True`` with `indicate_error` plot simple
   error bars by default instead of bars and "boxes" (:commit:`4e30f415`). Only plot
   "boxes" with central "markers" by default for violin plots (:commit:`13b45ccd`).
-* `legend_wrapper` no longer returns the background patch generated for centered-row
-  legends (:pr:`254`). This is consistent with `colorbar_wrapper` not returning
+* `legend_extras` no longer returns the background patch generated for centered-row
+  legends (:pr:`254`). This is consistent with `colorbar_extras` not returning
   background patches generated for inset colorbars. Until proplot adds new subclasses,
   it makes more sense if these functions only return `~matplotlib.legend.Legend` and
   `~matplotlib.colorbar.Colorbar` instances.
@@ -129,8 +129,16 @@ ProPlot v0.7.0 (2021-07-##)
 * Add `wequal`, `hequal`, and `equal` options to still use automatic spacing but force
   the tight layout algorithm to make spacings equal (:pr:`215`, :issue:`64`)
   by `Zachary Moon`_.
-* Add baseline support for "3D" `~matplotlib.mpl_toolkits.mplot3d.Axes3D` axes
+* Add minimal support for "3D" `~matplotlib.mpl_toolkits.mplot3d.Axes3D` axes
   (:issue:`249`). Example usage: ``fig.subplots(proj='3d')``.
+* Add `~proplot.axes.Axes.plotx` and `~proplot.axes.Axes.scatterx` commands that
+  interpret plotting args as ``(y, x)`` rather than ``(x, y)``, analogous to
+  `~proplot.axes.Axes.areax` (:commit:`###`).
+* Add support for `~proplot.axes.indicate_error` *horizontal* error bars and
+  shading for line and scatter plots (:commit:`###`).
+* Add support for ``ax.plot_command('x_key', 'y_key', data=dataset)`` for
+  virtually all plotting commands using `standardize_1d` and `standardize_2d`
+  (:commit:`###`). This was an existing `~matplotlib.axes.Axes.plot` feature.
 * Allow updating axes fonts that use scalings like ``'small'`` and ``'large'``
   by passing ``fontsize=N`` to `format` (:issue:`212`).
 * Interpret fontsize-relative legend rc params like ``legend.borderpad``
@@ -184,6 +192,9 @@ ProPlot v0.7.0 (2021-07-##)
   ``'a'`` or ``'A'`` in string, and only replace that one (:issue:`201`).
 * Allow passing e.g. ``barstds=3`` or ``barpctiles=90`` to request error bars
   denoting +/-3 standard deviations and 5-95 percentile range (:commit:`4e30f415`).
+* Add singular `indicate_error` keywords `barstd`, `barpctile`, etc. as
+  alternatives to `barstds`, `barpctiles`, etc. (:commit:`81151a58`).
+  Also prefer them in the documentation.
 * Allow passing ``means=True`` to `boxplot` to toggle mean line
   (:commit:`4e30f415`).
 * Allow setting the mean and median boxplot linestyle with

--- a/docs/1dplots.py
+++ b/docs/1dplots.py
@@ -195,81 +195,126 @@ with plot.rc.context({'lines.linewidth': 3}):
 
 
 # %% [raw] raw_mimetype="text/restructuredtext"
-# .. _ug_errorbars:
+# .. _ug_lines:
 #
-# Shading and error bars
-# ----------------------
+# Line plots
+# ----------
 #
-# The `~proplot.axes.indicate_error` wrapper lets you draw error bars
-# and error shading on-the-fly by passing certain keyword arguments to
-# `~matplotlib.axes.Axes.plot`, `~matplotlib.axes.Axes.scatter`,
-# `~matplotlib.axes.Axes.bar`, or `~matplotlib.axes.Axes.barh`.
+# The `~matplotlib.axes.Axes.plot` command is wrapped by
+# `~proplot.axes.apply_cycle` and `~proplot.axes.standardize_1d`.
+# Its behavior is the same -- ProPlot simply tries to expand
+# the flexibility of this command to the rest of the 1D plotting commands.
+# The new `~proplot.axes.Axes.plotx` command can be used just like
+# `~matplotlib.axes.Axes.plotx`, except a single argument is interpreted
+# as *x* coordinates (with default *y* coordinates inferred from the data),
+# and multiple arguments are interpreted as *y* and *x* coordinates (in that order).
+# This is analogous to `~matplotlib.axes.Axes.barh` and
+# `~matplotlib.axes.Axes.fill_betweenx`.
 #
-# If you pass 2D arrays to these methods with ``mean=True`` or ``median=True``,
-# the means or medians of each column are drawn as points, lines, or bars, and
-# *error bars* or *shading* is drawn to represent the spread of the distribution
-# for each column. You can also specify the error bounds *manually* with the
-# `bardata`, `boxdata`, `shadedata`, and `fadedata` keywords.
-# `~proplot.axes.indicate_error` can draw thin error bars with optional whiskers,
-# thick "boxes" overlayed on top of these bars (think of these as miniature boxplots),
-# and up to 2 layers of shading. See `~proplot.axes.indicate_error` for details.
+# As with the other 1D plotting commands, `~matplotlib.axes.Axes.step`,
+# `~matplotlib.axes.Axes.hlines`, `~matplotlib.axes.Axes.vlines`, and
+# `~matplotlib.axes.Axes.stem` are wrapped by `~proplot.axes.standardize_1d`.
+# `~proplot.axes.Axes.step` now use the property cycle, just like
+# `~matplotlib.axes.Axes.plot`. `~matplotlib.axes.Axes.vlines` and
+# `~matplotlib.axes.Axes.hlines` are also wrapped by `~proplot.axes.vlines_extras`
+# and `~proplot.axes.hlines_extras`, which can use
+# different colors for "negative" and "positive" lines using ``negpos=True``
+# (the default colors are :rc:`negcolor` and :rc:`poscolor`).
 
+# %%
+import proplot as plot
+import numpy as np
+state = np.random.RandomState(51423)
+fig, axs = plot.subplots(ncols=2, nrows=2, share=0)
+axs.format(suptitle='Line plots demo', xlabel='xlabel', ylabel='ylabel')
+
+# Step
+ax = axs[0]
+data = state.rand(20, 4).cumsum(axis=1).cumsum(axis=0)
+cycle = ('blue7', 'gray5', 'red7', 'gray5')
+ax.step(data, cycle=cycle, labels=list('ABCD'), legend='ul', legend_kw={'ncol': 2})
+ax.format(title='Step plot')
+
+# Stems
+ax = axs[1]
+data = state.rand(20)
+ax.stem(data, linefmt='k-')
+ax.format(title='Stem plot')
+
+# Vertical lines
+gray = 'gray7'
+data = state.rand(20) - 0.5
+ax = axs[2]
+ax.area(data, color=gray, alpha=0.2)
+ax.vlines(data, negpos=True, linewidth=2)
+ax.format(title='Vertical lines')
+
+# Horizontal lines
+ax = axs[3]
+ax.areax(data, color=gray, alpha=0.2)
+ax.hlines(data, negpos=True, linewidth=2)
+ax.format(title='Horizontal lines')
+
+
+# %% [raw] raw_mimetype="text/restructuredtext"
+# .. _ug_scatter:
+#
+# Scatter plots
+# -------------
+#
+# The `~matplotlib.axes.Axes.scatter` command is wrapped by
+# `~proplot.axes.scatter_extras`, `~proplot.axes.apply_cycle`, and
+# `~proplot.axes.standardize_1d`. This means that
+# `~matplotlib.axes.Axes.scatter` now accepts 2D *y* coordinates and permits
+# omitting *x* coordinates, just like `~matplotlib.axes.Axes.plot`.
+# `~matplotlib.axes.Axes.scatter` now also accepts keywords that look like
+# `~matplotlib.axes.Axes.plot` keywords (e.g., `color` instead of `c` and
+# `markersize` instead of `s`). This way, `~matplotlib.axes.Axes.scatter` can
+# optionally be used simply to "plot markers, not lines" without changing the
+# input arguments relative to `~matplotlib.axes.Axes.plot`.
+#
+# Just like `~matplotlib.axes.Axes.plot`, the property cycle is used
+# with `~matplotlib.axes.Axes.scatter` plots by default. It can be changed
+# using the `cycle` keyword argument, and it can include properties like `marker`
+# and `markersize`. The colormap `cmap` and normalizer `norm` used with the
+# optional `c` color array are now passed through the `~proplot.constructor.Colormap`
+# and `~proplot.constructor.Norm` constructor functions, and the the `s` marker
+# size array can now be conveniently scaled using the arguments `smin` and `smax`
+# (analogous to `vmin` and `vmax` used for colors).
 
 # %%
 import proplot as plot
 import numpy as np
 import pandas as pd
-plot.rc['title.loc'] = 'uc'
 
 # Sample data
 state = np.random.RandomState(51423)
-data = state.rand(20, 8).cumsum(axis=0).cumsum(axis=1)[:, ::-1]
-data = data + 20 * state.normal(size=(20, 8)) + 30
-data = pd.DataFrame(data, columns=np.arange(0, 16, 2))
-data.name = 'variable'
+x = (state.rand(20) - 0).cumsum()
+data = (state.rand(20, 4) - 0.5).cumsum(axis=0)
+data = pd.DataFrame(data, columns=pd.Index(['a', 'b', 'c', 'd'], name='label'))
 
 # Figure
-fig, axs = plot.subplots(
-    nrows=3, refaspect=1.5, refwidth=4,
-    share=0, hratios=(2, 1, 1)
-)
-axs.format(suptitle='Indicating error bounds')
-axs[1:].format(xlabel='column number', xticks=1, xgrid=False)
+fig, axs = plot.subplots(ncols=2, share=1)
+axs.format(suptitle='Scatter plot demo')
 
-# Medians and percentile ranges
+# Scatter plot with property cycler
 ax = axs[0]
-obj = ax.barh(
-    data, color='light red', legend=True,
-    median=True, barpctile=90, boxpctile=True,
-    # median=True, barpctile=(5, 95), boxpctile=(25, 75)  # equivalent
+ax.format(title='With property cycle')
+obj = ax.scatter(
+    x, data, legend='ul', cycle='Set2', legend_kw={'ncols': 2},
+    cycle_kw={'marker': ['x', 'o', 'x', 'o'], 'markersize': [5, 10, 20, 30]}
 )
-ax.format(title='Column statistics')
-ax.format(ylabel='column number', title='Bar plot', ygrid=False)
 
-# Means and standard deviation range
+# Scatter plot with colormap
 ax = axs[1]
-ax.scatter(
-    data, color='denim', marker='x', markersize=8**2, linewidth=0.8, legend='ll',
-    label='mean', shadelabel=True,
-    mean=True, shadestd=1,
-    # mean=True, shadestd=(-1, 1)  # equivalent
+ax.format(title='With colormap')
+data = state.rand(2, 100)
+obj = ax.scatter(
+    *data, color=data.sum(axis=0), size=state.rand(100), smin=3, smax=30,
+    marker='o', cmap='dark red', cmap_kw={'fade': 90}, vmin=0, vmax=2,
+    colorbar='lr', colorbar_kw={'label': 'label', 'locator': 0.5},
 )
-ax.format(title='Marker plot')
-
-# User-defined error bars
-ax = axs[2]
-means = data.mean(axis=0)
-means.name = data.name
-shadedata = np.percentile(data, (25, 75), axis=0)  # dark shading
-fadedata = np.percentile(data, (5, 95), axis=0)  # light shading
-ax.plot(
-    means,
-    shadedata=shadedata, fadedata=fadedata,
-    label='mean', shadelabel='50% CI', fadelabel='90% CI',
-    color='ocean blue', barzorder=0, boxmarker=False, legend='ll',
-)
-ax.format(title='Line plot')
-plot.rc.reset()
+axs.format(xlabel='xlabel', ylabel='ylabel')
 
 
 # %% [raw] raw_mimetype="text/restructuredtext"
@@ -393,6 +438,84 @@ axs[1].format(title='Area plot')
 
 
 # %% [raw] raw_mimetype="text/restructuredtext"
+# .. _ug_errorbars:
+#
+# Shading and error bars
+# ----------------------
+#
+# The `~proplot.axes.indicate_error` wrapper lets you draw error bars
+# and error shading on-the-fly by passing certain keyword arguments to
+# `~matplotlib.axes.Axes.plot`, `~matplotlib.axes.Axes.scatter`,
+# `~matplotlib.axes.Axes.bar`, or `~matplotlib.axes.Axes.barh`.
+#
+# If you pass 2D arrays to these methods with ``mean=True`` or ``median=True``,
+# the means or medians of each column are drawn as points, lines, or bars, and
+# *error bars* or *shading* is drawn to represent the spread of the distribution
+# for each column. You can also specify the error bounds *manually* with the
+# `bardata`, `boxdata`, `shadedata`, and `fadedata` keywords.
+# `~proplot.axes.indicate_error` can draw thin error bars with optional whiskers,
+# thick "boxes" overlayed on top of these bars (think of these as miniature boxplots),
+# and up to 2 layers of shading. See `~proplot.axes.indicate_error` for details.
+
+
+# %%
+import proplot as plot
+import numpy as np
+import pandas as pd
+plot.rc['title.loc'] = 'uc'
+
+# Sample data
+state = np.random.RandomState(51423)
+data = state.rand(20, 8).cumsum(axis=0).cumsum(axis=1)[:, ::-1]
+data = data + 20 * state.normal(size=(20, 8)) + 30
+data = pd.DataFrame(data, columns=np.arange(0, 16, 2))
+data.name = 'variable'
+
+# Figure
+fig, axs = plot.subplots(
+    nrows=3, refaspect=1.5, refwidth=4,
+    share=0, hratios=(2, 1, 1)
+)
+axs.format(suptitle='Indicating error bounds')
+axs[1:].format(xlabel='column number', xticks=1, xgrid=False)
+
+# Medians and percentile ranges
+ax = axs[0]
+obj = ax.barh(
+    data, color='light red', legend=True,
+    median=True, barpctile=90, boxpctile=True,
+    # median=True, barpctile=(5, 95), boxpctile=(25, 75)  # equivalent
+)
+ax.format(title='Column statistics')
+ax.format(ylabel='column number', title='Bar plot', ygrid=False)
+
+# Means and standard deviation range
+ax = axs[1]
+ax.scatter(
+    data, color='denim', marker='x', markersize=8**2, linewidth=0.8, legend='ll',
+    label='mean', shadelabel=True,
+    mean=True, shadestd=1,
+    # mean=True, shadestd=(-1, 1)  # equivalent
+)
+ax.format(title='Marker plot')
+
+# User-defined error bars
+ax = axs[2]
+means = data.mean(axis=0)
+means.name = data.name
+shadedata = np.percentile(data, (25, 75), axis=0)  # dark shading
+fadedata = np.percentile(data, (5, 95), axis=0)  # light shading
+ax.plot(
+    means,
+    shadedata=shadedata, fadedata=fadedata,
+    label='mean', shadelabel='50% CI', fadelabel='90% CI',
+    color='ocean blue', barzorder=0, boxmarker=False, legend='ll',
+)
+ax.format(title='Line plot')
+plot.rc.reset()
+
+
+# %% [raw] raw_mimetype="text/restructuredtext"
 # .. _ug_boxplots:
 #
 # Box plots and violin plots
@@ -447,127 +570,6 @@ colors = plot.Colors('pastel2')  # list of colors from the cycle
 ax.boxplot(data, fillcolor=colors, orientation='horizontal')
 ax.format(title='Multiple colors', titleloc='uc', ymargin=0.15)
 
-
-# %% [raw] raw_mimetype="text/restructuredtext"
-# .. _ug_lines:
-#
-# Line plots
-# ----------
-#
-# The `~matplotlib.axes.Axes.plot` command is wrapped by
-# `~proplot.axes.apply_cycle` and `~proplot.axes.standardize_1d`.
-# But in general, its behavior is the same -- ProPlot simply tries to expand
-# the flexibility of this command to the rest of the 1D plotting commands.
-# The new `~proplot.axes.Axes.plotx` command can be used just like
-# `~matplotlib.axes.Axes.plotx`, except a single argument is interpreted
-# as *x* coordinates (with default *y* coordinates inferred from the data),
-# and multiple arguments are interpreted as *y* and *x* coordinates (in that order).
-# This is analogous to `~matplotlib.axes.Axes.barh` and
-# `~matplotlib.axes.Axes.fill_betweenx`.
-#
-# As with the other 1D plotting commands, `~matplotlib.axes.Axes.step`,
-# `~matplotlib.axes.Axes.hlines`, `~matplotlib.axes.Axes.vlines`, and
-# `~matplotlib.axes.Axes.stem` are wrapped by `~proplot.axes.standardize_1d`.
-# `~proplot.axes.Axes.step` now use the property cycle, just like
-# `~matplotlib.axes.Axes.plot`. `~matplotlib.axes.Axes.vlines` and
-# `~matplotlib.axes.Axes.hlines` are also wrapped by `~proplot.axes.vlines_extras`
-# and `~proplot.axes.hlines_extras`, which can use
-# different colors for "negative" and "positive" lines using ``negpos=True``
-# (the default colors are :rc:`negcolor` and :rc:`poscolor`).
-
-# %%
-import proplot as plot
-import numpy as np
-state = np.random.RandomState(51423)
-fig, axs = plot.subplots(ncols=2, nrows=2, share=0)
-axs.format(suptitle='Line plots demo', xlabel='xlabel', ylabel='ylabel')
-
-# Step
-ax = axs[0]
-data = state.rand(20, 4).cumsum(axis=1).cumsum(axis=0)
-cycle = ('blue7', 'gray5', 'red7', 'gray5')
-ax.step(data, cycle=cycle, labels=list('ABCD'), legend='ul', legend_kw={'ncol': 2})
-ax.format(title='Step plot')
-
-# Stems
-ax = axs[1]
-data = state.rand(20)
-ax.stem(data, linefmt='k-')
-ax.format(title='Stem plot')
-
-# Vertical lines
-gray = 'gray7'
-data = state.rand(20) - 0.5
-ax = axs[2]
-ax.area(data, color=gray, alpha=0.2)
-ax.vlines(data, negpos=True, linewidth=2)
-ax.format(title='Vertical lines')
-
-# Horizontal lines
-ax = axs[3]
-ax.areax(data, color=gray, alpha=0.2)
-ax.hlines(data, negpos=True, linewidth=2)
-ax.format(title='Horizontal lines')
-
-# %% [raw] raw_mimetype="text/restructuredtext"
-# .. _ug_scatter:
-#
-# Scatter plots
-# -------------
-#
-# The `~matplotlib.axes.Axes.scatter` command is wrapped by
-# `~proplot.axes.scatter_extras`, `~proplot.axes.apply_cycle`, and
-# `~proplot.axes.standardize_1d`. This means that
-# `~matplotlib.axes.Axes.scatter` now accepts 2D *y* coordinates and permits
-# omitting *x* coordinates, just like `~matplotlib.axes.Axes.plot`.
-# `~matplotlib.axes.Axes.scatter` now also accepts keywords that look like
-# `~matplotlib.axes.Axes.plot` keywords (e.g., `color` instead of `c` and
-# `markersize` instead of `s`). This way, `~matplotlib.axes.Axes.scatter` can
-# optionally be used simply to "plot markers, not lines" without changing the
-# input arguments relative to `~matplotlib.axes.Axes.plot`.
-#
-# Just like `~matplotlib.axes.Axes.plot`, the property cycle is used
-# with `~matplotlib.axes.Axes.scatter` plots by default. It can be changed
-# using the `cycle` keyword argument, and it can include properties like `marker`
-# and `markersize`. The colormap `cmap` and normalizer `norm` used with the
-# optional `c` color array are now passed through the `~proplot.constructor.Colormap`
-# and `~proplot.constructor.Norm` constructor functions, and the the `s` marker
-# size array can now be conveniently scaled using the arguments `smin` and `smax`
-# (analogous to `vmin` and `vmax` used for colors).
-
-# %%
-import proplot as plot
-import numpy as np
-import pandas as pd
-
-# Sample data
-state = np.random.RandomState(51423)
-x = (state.rand(20) - 0).cumsum()
-data = (state.rand(20, 4) - 0.5).cumsum(axis=0)
-data = pd.DataFrame(data, columns=pd.Index(['a', 'b', 'c', 'd'], name='label'))
-
-# Figure
-fig, axs = plot.subplots(ncols=2, share=1)
-axs.format(suptitle='Scatter plot demo')
-
-# Scatter plot with property cycler
-ax = axs[0]
-ax.format(title='With property cycle')
-obj = ax.scatter(
-    x, data, legend='ul', cycle='Set2', legend_kw={'ncols': 2},
-    cycle_kw={'marker': ['x', 'o', 'x', 'o'], 'markersize': [5, 10, 20, 30]}
-)
-
-# Scatter plot with colormap
-ax = axs[1]
-ax.format(title='With colormap')
-data = state.rand(2, 100)
-obj = ax.scatter(
-    *data, color=data.sum(axis=0), size=state.rand(100), smin=3, smax=30,
-    marker='o', cmap='dark red', cmap_kw={'fade': 90}, vmin=0, vmax=2,
-    colorbar='lr', colorbar_kw={'label': 'label', 'locator': 0.5},
-)
-axs.format(xlabel='xlabel', ylabel='ylabel')
 
 # %% [raw] raw_mimetype="text/restructuredtext"
 # .. _ug_parametric:

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -112,8 +112,16 @@ h5{
 h6{
   font-size: 100%;
 }
+.rst-content dl:not(.docutils) dt,
+.rst-content dl:not(.docutils) .field-list>dt {
+  font-size: 100%; /* default is 90% */
+}
 .wy-menu-vertical header, .wy-menu-vertical p.caption {
-  font-size: 90%;  /* default is 85% */
+  font-size: 100%;  /* default is 85% */
+  padding: 0 1.4em;  /* fix alignment */
+}
+.wy-menu-vertical a {
+  padding: 0.4em 1.6em  /* mostly unchanged */
 }
 
 /* RST content background color */
@@ -298,8 +306,8 @@ code,
 
 /* Parameters and Returns header colors */
 .rst-content dl:not(.docutils) .field-list>dt {
-  font-weight: bold;
   color: var(--main-color);
+  font-weight: bold;
   background: var(--block-bg-color);
   border-left-color: var(--accent-bg-color);
   /* padding: 0; */ /* remove accents, decided against this */

--- a/docs/axis.py
+++ b/docs/axis.py
@@ -31,7 +31,7 @@
 # --------------
 #
 # `Tick locators\
-# <https://matplotlib.org/3.2.1/gallery/ticks_and_spines/tick-locators.html>`__
+# <https://matplotlib.org/stable/gallery/ticks_and_spines/tick-locators.html>`__
 # are used to automatically select sensible tick locations
 # based on the axis data limits. In ProPlot, you can change the tick locator
 # using the `~proplot.axes.Axes.format` keyword arguments `xlocator`,
@@ -126,7 +126,7 @@ axs[7].format(
 # -----------
 #
 # `Tick formatters\
-# <https://matplotlib.org/3.2.1/gallery/ticks_and_spines/tick-formatters.html>`__
+# <https://matplotlib.org/stable/gallery/ticks_and_spines/tick-formatters.html>`__
 # are used to convert floating point numbers to
 # nicely-formatted tick labels. In ProPlot, you can change the tick formatter
 # using the `~proplot.axes.Axes.format` keyword arguments `xformatter` and
@@ -493,7 +493,7 @@ for ax, scale, color in zip(axs[4:], ('sine', 'mercator'), ('coral', 'sky blue')
 # In the below examples, we generate dual axes with each of these three methods. Note
 # that the "parent" axis scale is now arbitrary -- in the first example shown below,
 # we create a `~proplot.axes.CartesianAxes.dualx` axis for an axis scaled by the
-# `symlog scale <https://matplotlib.org/3.1.0/gallery/scales/symlog_demo.html>`__.
+# `symlog scale <https://matplotlib.org/stable/gallery/scales/symlog_demo.html>`__.
 
 # %%
 import proplot as plot

--- a/docs/basics.py
+++ b/docs/basics.py
@@ -153,7 +153,7 @@ axs[0].plot(data, lw=2)
 # --------------
 #
 # Matplotlib has
-# `two different interfaces <https://matplotlib.org/3.2.1/api/index.html>`__:
+# `two different interfaces <https://matplotlib.org/stable/api/index.html>`__:
 # an object-oriented interface and a MATLAB-style `~matplotlib.pyplot` interface
 # (which uses the object-oriented interface internally). Plotting with ProPlot is
 # just like plotting with matplotlib's *object-oriented* interface. Proplot builds
@@ -321,7 +321,7 @@ for ax in axs[1:, 1:]:
 # :ref:`ProPlot settings <rc_proplot>`. `~proplot.config.rc` also
 # provides a ``style`` parameter that can be used to switch between
 # `matplotlib stylesheets\
-# <https://matplotlib.org/3.1.1/gallery/style_sheets/style_sheets_reference.html>`__.
+# <https://matplotlib.org/stable/gallery/style_sheets/style_sheets_reference.html>`__.
 # See the :ref:`configuration section <ug_config>` for details.
 #
 # To modify a setting for just one subplot, you can pass it to the

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -98,7 +98,7 @@ The .proplotrc file
 
 When you install ProPlot for the first time, a ``.proplotrc`` file is generated
 and placed in your home directory. This is just like the `matplotlibrc file\
-<https://matplotlib.org/3.1.1/tutorials/introductory/customizing.html#customizing-with-matplotlibrc-files>`__,
+<https://matplotlib.org/stable/tutorials/introductory/customizing.html#customizing-with-matplotlibrc-files>`__,
 but for changing both ProPlot *and* matplotlib settings. The syntax is basically
 the same as the ``matplotlibrc`` syntax.
 

--- a/docs/cycles.py
+++ b/docs/cycles.py
@@ -26,7 +26,7 @@
 # instances so that they can be `used with categorical data\
 # <https://journals.ametsoc.org/view-large/figure/9538246/bams-d-13-00155_1-f5.tif>`__.
 # Much more commonly, we build `property cycles\
-# <https://matplotlib.org/3.1.0/tutorials/intermediate/color_cycle.html>`__
+# <https://matplotlib.org/stable/tutorials/intermediate/color_cycle.html>`__
 # from the `~proplot.colors.ListedColormap` colors using the
 # `~proplot.constructor.Cycle` constructor function or by
 # :ref:`drawing samples <ug_cycles_new>` from continuous colormaps.

--- a/docs/fonts.py
+++ b/docs/fonts.py
@@ -32,7 +32,7 @@
 #
 # Matplotlib provides a `~matplotlib.font_manager` module for working with
 # system fonts and classifies fonts into `five font families\
-# <https://matplotlib.org/3.1.1/gallery/text_labels_and_annotations/fonts_demo.html>`__:
+# <https://matplotlib.org/stable/gallery/text_labels_and_annotations/fonts_demo.html>`__:
 # :rcraw:`font.serif` :rcraw:`font.sans-serif`, :rcraw:`font.monospace`,
 # :rcraw:`font.cursive`, and :rcraw:`font.fantasy`. The default font family
 # is sans-serif, because sans-serif fonts are generally more suitable for

--- a/docs/insets_panels.py
+++ b/docs/insets_panels.py
@@ -115,7 +115,7 @@ for ax, side in zip(axs, 'tlbr'):
 # ----------
 #
 # `Inset axes\
-# <https://matplotlib.org/3.1.1/gallery/subplots_axes_and_figures/zoom_inset_axes.html>`__
+# <https://matplotlib.org/stable/gallery/subplots_axes_and_figures/zoom_inset_axes.html>`__
 # can be generated with the `~proplot.axes.Axes.inset` or
 # `~proplot.axes.Axes.inset_axes` command. By default, inset axes
 # have the same projection as the parent axes, but you can also request

--- a/docs/projections.py
+++ b/docs/projections.py
@@ -15,7 +15,7 @@
 
 # %% [raw] raw_mimetype="text/restructuredtext"
 #
-# .. _polar: https://matplotlib.org/3.1.0/gallery/pie_and_polar_charts/polar_demo.html
+# .. _polar: https://matplotlib.org/stable/gallery/pie_and_polar_charts/polar_demo.html
 #
 # .. _cartopy: https://scitools.org.uk/cartopy/docs/latest/
 #
@@ -241,7 +241,7 @@ plot.rc.reset()
 # `~mpl_toolkits.basemap.addcyclic`.
 #
 # Geographic features can be drawn underneath data or on top of data by changing the
-# corresponding `zorder <https://matplotlib.org/3.1.1/gallery/misc/zorder_demo.html>`__
+# corresponding `zorder <https://matplotlib.org/stable/gallery/misc/zorder_demo.html>`__
 # setting. For example, to draw land patches on top of all plotted content as
 # a "land mask," use ``ax.format(land=True, landzorder=4)`` or set :rcraw:`land.zorder`
 # to ``True``. See the :ref:`next section <ug_geoformat>` for details.

--- a/docs/subplots.py
+++ b/docs/subplots.py
@@ -63,7 +63,7 @@
 #      `nrows` arguments), the arguments `refaspect`, `refwidth`, and `refheight`
 #      apply to every subplot in the figure -- not just the reference subplot.
 #    * When the reference subplot `aspect ratio\
-#      <https://matplotlib.org/2.0.2/examples/pylab_examples/equal_aspect_ratio.html>`__
+#      <https://matplotlib.org/stable/examples/pylab_examples/equal_aspect_ratio.html>`__
 #      has been fixed (e.g., using ``ax.set_aspect(1)``) or is set to ``'equal'``
 #      (as with :ref:`geographic projections <ug_geo>` and
 #      `~matplotlib.axes.Axes.imshow` images), the fixed aspect ratio is used
@@ -157,7 +157,7 @@ for ref in (1, 2):
 # subplot rows and columns and the figure edge to accommodate labels.
 # It can be disabled by passing ``tight=False`` to `~proplot.ui.subplots`.
 # While matplotlib has `its own tight layout algorithm
-# <https://matplotlib.org/3.1.1/tutorials/intermediate/tight_layout_guide.html>`__,
+# <https://matplotlib.org/stable/tutorials/intermediate/tight_layout_guide.html>`__,
 # ProPlot's algorithm may change the figure size to accommodate the correct spacing
 # and permits variable spacing between subsequent subplot rows and columns (see the
 # new `~proplot.gridspec.GridSpec` class for details).

--- a/docs/why.rst
+++ b/docs/why.rst
@@ -142,11 +142,11 @@ seconds, typing out these extra class names and import statements can be a major
 
 Parts of matplotlib's interface were actually designed with this in mind.
 `Backend classes <https://matplotlib.org/faq/usage_faq.html#what-is-a-backend>`__,
-`native axes projections <https://matplotlib.org/3.1.1/api/projections_api.html>`__,
-`axis scales <https://matplotlib.org/3.1.0/gallery/scales/scales.html>`__,
-`box styles <https://matplotlib.org/3.1.1/api/_as_gen/matplotlib.patches.FancyBboxPatch.html?highlight=boxstyle>`__,
-`arrow styles <https://matplotlib.org/3.1.1/api/_as_gen/matplotlib.patches.FancyArrowPatch.html?highlight=arrowstyle>`__,
-and `arc styles <https://matplotlib.org/3.1.1/api/_as_gen/matplotlib.patches.ConnectionStyle.html?highlight=class%20name%20attrs>`__
+`native axes projections <https://matplotlib.org/stable/api/projections_api.html>`__,
+`axis scales <https://matplotlib.org/stable/gallery/scales/scales.html>`__,
+`box styles <https://matplotlib.org/stable/api/_as_gen/matplotlib.patches.FancyBboxPatch.html>`__,
+`arrow styles <https://matplotlib.org/stable/api/_as_gen/matplotlib.patches.FancyArrowPatch.html>`__,
+and `arc styles <https://matplotlib.org/stable/api/_as_gen/matplotlib.patches.ConnectionStyle.html>`__
 are referenced with "registered" string names,
 as are `basemap projections <https://matplotlib.org/basemap/users/mapsetup.html>`__.
 So, why not "register" everything else?
@@ -208,7 +208,7 @@ figure, despite the fact that...
    number of subplot tiles in the figure.
 
 Also, while matplotlib's `tight layout algorithm
-<https://matplotlib.org/tutorials/intermediate/tight_layout_guide.html>`__
+<https://matplotlib.org/stable/tutorials/intermediate/tight_layout_guide.html>`__
 helps to avoid tweaking the *spacing*, the algorithm cannot apply different amounts of
 spacing between different subplot row and column boundaries.
 
@@ -218,7 +218,7 @@ In ProPlot, you can specify the physical dimensions of a *reference subplot*
 instead of the figure by passing `refwidth`, `refheight`, and/or `refaspect` to
 `~proplot.figure.Figure`. The default behavior is ``refaspect=1`` and
 ``refwidth=2`` (inches). If the `aspect ratio mode
-<https://matplotlib.org/2.0.2/examples/pylab_examples/equal_aspect_ratio.html>`__
+<https://matplotlib.org/stable/gallery/subplots_axes_and_figures/axis_equal_demo.html>`__
 for the reference subplot is set to ``'equal'``, as with
 :ref:`geographic and polar <ug_proj>` plots and `~matplotlib.axes.Axes.imshow` plots,
 the *imposed* aspect ratio will be used instead.
@@ -331,7 +331,7 @@ difficult to draw "inset" colorbars in matplotlib.
 
 ..
    The matplotlib example for `~matplotlib.figure.Figure` legends is `not pretty
-   <https://matplotlib.org/3.1.1/gallery/text_labels_and_annotations/figlegend_demo.html>`__.
+   <https://matplotlib.org/stable/gallery/text_labels_and_annotations/figlegend_demo.html>`__.
 
 ..
    Drawing colorbars and legends is pretty clumsy in matplotlib -- especially

--- a/proplot/axes/base.py
+++ b/proplot/axes/base.py
@@ -1900,17 +1900,17 @@ class Axes(maxes.Axes):
     stem = wrap._apply_wrappers(
         maxes.Axes.stem,
         wrap.standardize_1d,
-        wrap._stem_extras,  # TODO check this
+        wrap._stem_extras,
     )
     vlines = wrap._apply_wrappers(
         maxes.Axes.vlines,
         wrap.standardize_1d,
-        wrap.vlines_extras,  # TODO check this
+        wrap.vlines_extras,
     )
     hlines = wrap._apply_wrappers(
         maxes.Axes.hlines,
         wrap.standardize_1d,
-        wrap.hlines_extras,  # TODO check this
+        wrap.hlines_extras,
     )
     scatter = wrap._apply_wrappers(
         maxes.Axes.scatter,
@@ -1935,7 +1935,10 @@ class Axes(maxes.Axes):
     )
     barh = wrap._apply_wrappers(
         maxes.Axes.barh,
+        wrap.standardize_1d,
         wrap.barh_extras,
+        wrap.indicate_error,
+        wrap.apply_cycle,
     )
     hist = wrap._apply_wrappers(
         maxes.Axes.hist,

--- a/proplot/axes/base.py
+++ b/proplot/axes/base.py
@@ -89,8 +89,7 @@ Parameters
 ----------
 bounds : list of float
     The bounds for the inset axes, listed as ``(x, y, width, height)``.
-transform : {'data', 'axes', 'figure'} or \
-`~matplotlib.transforms.Transform`, optional
+transform : {'data', 'axes', 'figure'} or `~matplotlib.transforms.Transform`, optional
     The transform used to interpret `bounds`. Can be a
     `~matplotlib.transforms.Transform` object or a string representing
     the `~matplotlib.axes.Axes.transData`,
@@ -113,7 +112,7 @@ basemap : bool or dict-like, optional
     Whether to use `~mpl_toolkits.basemap.Basemap` or
     `~cartopy.crs.Projection` for map projections. Default is ``False``.
 zorder : float, optional
-    The `zorder <https://matplotlib.org/3.1.1/gallery/misc/zorder_demo.html>`__
+    The `zorder <https://matplotlib.org/stable/gallery/misc/zorder_demo.html>`__
     of the axes, should be greater than the zorder of
     elements in the parent axes. Default is ``4``.
 zoom : bool, optional
@@ -728,8 +727,8 @@ class Axes(maxes.Axes):
             lower right inside axes   ``'lower right'``, ``'lr'``
             ========================  ============================
 
-        ltitle, ctitle, rtitle, ultitle, uctitle, urtitle, lltitle, lctitle, \
-lrtitle : str, optional
+        ltitle, ctitle, rtitle, ultitle, uctitle, urtitle, lltitle, lctitle, lrtitle \
+: str, optional
             Axes titles in specific positions. Works as an alternative to
             ``ax.format(title='title', titleloc='loc')`` and lets you specify
             multiple title-like labels in a single subplot.
@@ -749,8 +748,7 @@ lrtitle : str, optional
         titleabove : bool, optional
             Whether to try to put outer titles and a-b-c labels above panels,
             colorbars, or legends that are above the axes. Default is :rc:`title.above`.
-        leftlabels, toplabels, rightlabels, bottomlabels : list of str, \
-optional
+        leftlabels, toplabels, rightlabels, bottomlabels : list of str, optional
             Labels for the subplots lying along the left, top, right, and
             bottom edges of the figure. The length of each list must match
             the number of subplots along the corresponding edge.
@@ -1184,9 +1182,8 @@ optional
         capstyle : {'butt', 'round', 'projecting'}
             The cap style for the zoom lines and box outline.
         zorder : float, optional
-            The `zorder \
-<https://matplotlib.org/3.1.1/gallery/misc/zorder_demo.html>`__
-            of the axes, should be greater than the zorder of
+            The `zorder <https://matplotlib.org/stable/gallery/misc/zorder_demo.html>`__
+            of the zoom lines. Should be greater than the zorder of
             elements in the parent axes. Default is ``3.5``.
 
         Other parameters
@@ -1295,7 +1292,7 @@ optional
         -------
         `~matplotlib.collections.LineCollection`
             The parametric line. See `this matplotlib example \
-<https://matplotlib.org/gallery/lines_bars_and_markers/multicolored_line>`__.
+<https://matplotlib.org/stable/gallery/lines_bars_and_markers/multicolored_line>`__.
         """
         # NOTE: The 'extras' wrapper handles input before ingestion by other wrapper
         # functions. *This* method is analogous to a native matplotlib method.

--- a/proplot/axes/cartesian.py
+++ b/proplot/axes/cartesian.py
@@ -563,13 +563,13 @@ class CartesianAxes(base.Axes):
         xscale_kw, yscale_kw : dict-like, optional
             The *x* and *y* axis scale settings. Passed to
             `~proplot.scale.Scale`.
-        xspineloc, yspineloc : {'both', 'bottom', 'top', 'left', 'right', \
-'neither', 'center', 'zero'}, optional
+        xspineloc, yspineloc \
+: {'both', 'bottom', 'top', 'left', 'right', 'neither', 'center', 'zero'}, optional
             The *x* and *y* axis spine locations.
         xloc, yloc : optional
             Aliases for `xspineloc`, `yspineloc`.
-        xtickloc, ytickloc : {'both', 'bottom', 'top', 'left', 'right', \
-'neither'}, optional
+        xtickloc, ytickloc \
+: {'both', 'bottom', 'top', 'left', 'right', 'neither'}, optional
             Which *x* and *y* axis spines should have major and minor tick
             marks.
         xtickminor, ytickminor : bool, optional

--- a/proplot/axes/geo.py
+++ b/proplot/axes/geo.py
@@ -308,8 +308,8 @@ class GeoAxes(base.Axes):
         longridminor, latgridminor : bool, optional
             Whether to draw "minor" longitude and latitude lines.
             Default is :rc:`gridminor`. Use `gridminor` to toggle both.
-        lonlocator, latlocator : str, float, list of float, or \
-`~matplotlib.ticker.Locator`, optional
+        lonlocator, latlocator \
+: str, float, list of float, or `~matplotlib.ticker.Locator`, optional
             Used to determine the longitude and latitude gridline locations.
             Passed to the `~proplot.constructor.Locator` constructor. Can be
             string, float, list of float, or `matplotlib.ticker.Locator` instance.
@@ -330,8 +330,8 @@ class GeoAxes(base.Axes):
         lonminorlocator, latminorlocator, lonminorlines, latminorlines : optional
             As with `lonlocator` and `latlocator` but for the "minor" gridlines.
             The defaults are :rc:`grid.lonminorstep` and :rc:`grid.latminorstep`.
-        lonminorlocator_kw, latminorlocator_kw, lonminorlines_kw, latminorlines_kw : \
-optional
+        lonminorlocator_kw, latminorlocator_kw, lonminorlines_kw, latminorlines_kw \
+: optional
             As with `lonlocator_kw` and `latlocator_kw` but for the "minor" gridlines.
         latmax : float, optional
             The maximum absolute latitude for longitude and latitude gridlines.
@@ -399,8 +399,7 @@ optional
             *For cartopy axes only.*
             The number of interpolation steps used to draw gridlines.
             Default is :rc:`grid.nsteps`.
-        land, ocean, coast, rivers, lakes, borders, innerborders : bool, \
-optional
+        land, ocean, coast, rivers, lakes, borders, innerborders : bool, optional
             Toggles various geographic features. These are actually the
             :rcraw:`land`, :rcraw:`ocean`, :rcraw:`coast`, :rcraw:`rivers`,
             :rcraw:`lakes`, :rcraw:`borders`, and :rcraw:`innerborders`
@@ -1185,16 +1184,16 @@ class CartopyAxes(GeoAxes, GeoAxesBase):
         plot = wrap._apply_wrappers(
             GeoAxesBase.plot,
             wrap.default_transform,
-            wrap._plot_extras,
             wrap.standardize_1d,
+            wrap._plot_extras,
             wrap.indicate_error,
             wrap.apply_cycle,
         )
         scatter = wrap._apply_wrappers(
             GeoAxesBase.scatter,
             wrap.default_transform,
-            wrap.scatter_extras,
             wrap.standardize_1d,
+            wrap.scatter_extras,
             wrap.indicate_error,
             wrap.apply_cycle,
         )
@@ -1558,8 +1557,8 @@ class BasemapAxes(GeoAxes):
         maxes.Axes.plot,
         wrap._basemap_norecurse,
         wrap.default_latlon,
-        wrap._plot_extras,
         wrap.standardize_1d,
+        wrap._plot_extras,
         wrap.indicate_error,
         wrap.apply_cycle,
         wrap._basemap_redirect,
@@ -1568,8 +1567,8 @@ class BasemapAxes(GeoAxes):
         maxes.Axes.scatter,
         wrap._basemap_norecurse,
         wrap.default_latlon,
-        wrap.scatter_extras,
         wrap.standardize_1d,
+        wrap.scatter_extras,
         wrap.indicate_error,
         wrap.apply_cycle,
         wrap._basemap_redirect,

--- a/proplot/axes/plot.py
+++ b/proplot/axes/plot.py
@@ -232,7 +232,7 @@ negcolor, poscolor : color-spec, optional
     is ``False``. Defaults are :rc:`negcolor` and :rc:`poscolor`.
 where : ndarray, optional
     Boolean ndarray mask for points you want to shade. See `this example \
-<https://matplotlib.org/3.1.0/gallery/pyplots/whats_new_98_4_fill_between.html#sphx-glr-gallery-pyplots-whats-new-98-4-fill-between-py>`__.
+<https://matplotlib.org/stable/gallery/pyplots/whats_new_98_4_fill_between.html#sphx-glr-gallery-pyplots-whats-new-98-4-fill-between-py>`__.
 lw, linewidth : float, optional
     The edge width for the area patches.
 edgecolor : color-spec, optional
@@ -2049,8 +2049,8 @@ def boxplot_extras(
     meanls, medianls, meanlinestyle, medianlinestyle : line style-spec, optional
         The line style for the mean and median lines drawn horizontally
         across the box.
-    boxcolor, capcolor, whiskercolor, fliercolor, meancolor, mediancolor : \
-color-spec, list, optional
+    boxcolor, capcolor, whiskercolor, fliercolor, meancolor, mediancolor \
+: color-spec, list, optional
         The color of various boxplot components. If a list, it should be the
         same length as the number of objects. These are shorthands so you don't
         have to pass e.g. a ``boxprops`` dictionary.
@@ -2166,7 +2166,7 @@ def violinplot_extras(
     """
     Adds convenient keyword arguments and changes the default violinplot style
     to match `this matplotlib example \
-<https://matplotlib.org/3.1.0/gallery/statistics/customized_violin.html>`__.
+<https://matplotlib.org/stable/gallery/statistics/customized_violin.html>`__.
     It is also no longer possible to show minima and maxima with whiskers --
     while this is useful for `~matplotlib.axes.Axes.boxplot`\\ s it is
     redundant for `~matplotlib.axes.Axes.violinplot`\\ s.
@@ -2360,8 +2360,8 @@ def text_extras(
         The *x* and *y* coordinates for the text.
     text : str
         The text string.
-    transform : {{'data', 'axes', 'figure'}} \
-or `~matplotlib.transforms.Transform`, optional
+    transform \
+: {{'data', 'axes', 'figure'}} or `~matplotlib.transforms.Transform`, optional
         The transform used to interpret `x` and `y`. Can be a
         `~matplotlib.transforms.Transform` object or a string corresponding to
         `~matplotlib.axes.Axes.transData`, `~matplotlib.axes.Axes.transAxes`,
@@ -3286,7 +3286,7 @@ def apply_cmap(
     # plots by calling contour() after contourf() if 'linewidths' or
     # 'linestyles' are explicitly passed, but do not want to disable the
     # native matplotlib feature for manually coloring filled contours.
-    # https://matplotlib.org/3.1.1/api/_as_gen/matplotlib.axes.Axes.contourf
+    # https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.contourf
     add_contours = contourf and (linewidths is not None or linestyles is not None)
     use_cmap = colors is None or (not contour and (not contourf or add_contours))
     if not use_cmap:

--- a/proplot/axes/plot.py
+++ b/proplot/axes/plot.py
@@ -57,15 +57,15 @@ __all__ = [
     'colorbar_extras',
     'legend_extras',
     'text_extras',
+    'vlines_extras',
+    'hlines_extras',
+    'scatter_extras',
     'bar_extras',
     'barh_extras',
     'fill_between_extras',
     'fill_betweenx_extras',
     'boxplot_extras',
     'violinplot_extras',
-    'vlines_extras',
-    'hlines_extras',
-    'scatter_extras',
 ]
 
 

--- a/proplot/axes/plot.py
+++ b/proplot/axes/plot.py
@@ -1681,10 +1681,10 @@ def _apply_lines(
     # Parse input arguments
     method = kwargs.pop('_method')
     name = method.__name__
-    args = list(args)
     colors = _not_none(color=color, colors=colors)
     linestyles = _not_none(linestyle=linestyle, linestyles=linestyles)
     linewidths = _not_none(lw=lw, linewidth=linewidth, linewidths=linewidths)
+    args = list(args)
     if len(args) > 3:
         raise ValueError(f'Expected 1-3 positional args, got {len(args)}.')
     if len(args) == 2:  # empty possible
@@ -1759,9 +1759,9 @@ def _apply_scatter(
     """
     # Manage input arguments
     method = kwargs.pop('_method')
+    args = list(args)
     if len(args) > 4:
         raise ValueError(f'Expected 1-4 positional arguments, got {len(args)}.')
-    args = list(args)
     if len(args) == 4:
         c = _not_none(c_positional=args.pop(-1), c=c)
     if len(args) == 3:
@@ -1861,10 +1861,10 @@ def _apply_fill_between(
     name = method.__name__
     sx = 'y' if 'x' in name else 'x'  # i.e. fill_betweenx
     sy = 'x' if sx == 'y' else 'y'
-    args = list(args)
     stack = _not_none(stack=stack, stacked=stacked)
     color = _not_none(color=color, facecolor=facecolor)
     linewidth = _not_none(lw=lw, linewidth=linewidth, default=0)
+    args = list(args)
     if len(args) > 4:
         raise ValueError(f'Expected 1-4 positional args, got {len(args)}.')
     if len(args) == 4:
@@ -1988,6 +1988,7 @@ def _apply_bar(
     color = _not_none(color=color, facecolor=facecolor)
     linewidth = _not_none(lw=lw, linewidth=linewidth, default=rc['patch.linewidth'])
     kwargs.update({'linewidth': linewidth, 'edgecolor': edgecolor})
+    args = list(args)
     if len(args) > 4:
         raise ValueError(f'Expected 1-4 positional args, got {len(args)}.')
     if len(args) == 4 and stack:
@@ -2631,7 +2632,7 @@ def apply_cycle(
     # Parse input arguments
     # NOTE: Requires standardize_1d wrapper before reaching this.
     method = kwargs.pop('_method')
-    errobjs = kwargs.pop('_errobjs')
+    errobjs = kwargs.pop('_errobjs', None)
     name = method.__name__
     plot = name in ('plot',)
     scatter = name in ('scatter',)

--- a/proplot/axes/polar.py
+++ b/proplot/axes/polar.py
@@ -67,8 +67,7 @@ class PolarAxes(base.Axes, mproj.PolarAxes):
             The radial origin.
         theta0 : {'N', 'NW', 'W', 'SW', 'S', 'SE', 'E', 'NE'}
             The zero azimuth location.
-        thetadir : {1, -1, 'anticlockwise', 'counterclockwise', 'clockwise'}, \
-optional
+        thetadir : {1, -1, 'anticlockwise', 'counterclockwise', 'clockwise'}, optional
             The positive azimuth direction. Clockwise corresponds to ``-1``
             and anticlockwise corresponds to ``1``. Default is ``1``.
         thetamin, thetamax : float, optional

--- a/proplot/colors.py
+++ b/proplot/colors.py
@@ -2366,9 +2366,21 @@ class _ColorCache(dict):
 
 def _get_cmap(name=None, lut=None):
     """
-    Monkey patch for matplotlib `~matplotlib.get_cmap`. Permits case-insensitive
-    search of monkey-patched colormap database (which was broken in v3.2.0).
+    Return the registered colormap instance.
+
+    Parameters
+    ----------
+    name : `matplotlib.colors.Colormap` or str or None, optional
+        If a `~matplotlib.colors.Colormap` instance, it will be returned. Otherwise,
+        the name of the registered colormap will be looked up and resampled by `lut`.
+        If ``None``, the default colormap :rc:`image.cmap` is returned.
+    lut : int or None, optional
+        If `name` is not already a `~matplotlib.colors.Colormap` instance
+        and `lut` is not None, the colormap will be resampled to have `lut`
+        entries in the lookup table.
     """
+    # Monkey patch for matplotlib `~matplotlib.get_cmap`. Permits case-insensitive
+    # search of monkey-patched colormap database (which was broken in v3.2.0).
     if name is None:
         name = rcParams['image.cmap']
     if isinstance(name, mcolors.Colormap):

--- a/proplot/colors.py
+++ b/proplot/colors.py
@@ -22,13 +22,6 @@ from .internals import ic  # noqa: F401
 from .internals import _not_none, docstring, warnings
 from .utils import to_rgb, to_rgba, to_xyz, to_xyza
 
-if hasattr(mcm, '_cmap_registry'):
-    _cmap_database_attr = '_cmap_registry'
-else:
-    _cmap_database_attr = 'cmap_d'
-_cmap_database = getattr(mcm, _cmap_database_attr)
-
-
 __all__ = [
     'ListedColormap',
     'LinearSegmentedColormap',
@@ -2564,12 +2557,16 @@ if not isinstance(mcolors._colors_full_map, ColorDatabase):
     mcolors.colorConverter.colors = _map
 
 # Replace colormap database with custom database
+# WARNING: Skip over the matplotlib native duplicate entries with
+# suffixes '_r' and '_shifted'.
+_cmap_database_attr = '_cmap_registry' if hasattr(mcm, '_cmap_registry') else 'cmap_d'
+_cmap_database = getattr(mcm, _cmap_database_attr)
 if mcm.get_cmap is not _get_cmap:
     mcm.get_cmap = _get_cmap
 if not isinstance(_cmap_database, ColormapDatabase):
     _cmap_database = {
         key: value for key, value in _cmap_database.items()
-        if key[-2:] != '_r' and key[-2:] != '_s'
+        if key[-2:] != '_r' and key[-8:] != '_shifted'
     }
     _cmap_database = ColormapDatabase(_cmap_database)
     setattr(mcm, _cmap_database_attr, _cmap_database)

--- a/proplot/colors.py
+++ b/proplot/colors.py
@@ -1620,8 +1620,7 @@ class PerceptuallyUniformColormap(LinearSegmentedColormap, _Colormap):
         ----------
         name : str
             The name of the new colormap. Default is ``self.name + '_copy'``.
-        segmentdata, N, alpha, clip, cyclic, gamma, gamma1, gamma2, space : \
-optional
+        segmentdata, N, alpha, clip, cyclic, gamma, gamma1, gamma2, space : optional
             See `PerceptuallyUniformColormap`. If not provided,
             these are copied from the current colormap.
         """

--- a/proplot/config.py
+++ b/proplot/config.py
@@ -1023,7 +1023,7 @@ class RcConfigurator(object):
                 '# Use this file to change the default proplot and matplotlib settings',
                 '# The syntax is identical to matplotlibrc syntax. For details see:',
                 '# https://proplot.readthedocs.io/en/latest/configuration.html',
-                '# https://matplotlib.org/3.1.1/tutorials/introductory/customizing',
+                '# https://matplotlib.org/stable/tutorials/introductory/customizing.html',  # noqa: E501
                 '#--------------------------------------------------------------------',
                 *rc_user,  # includes blank line
                 '# ProPlot settings',

--- a/proplot/constructor.py
+++ b/proplot/constructor.py
@@ -673,11 +673,11 @@ def Cycle(
         will be filled to match the length of the longest list.  See
         `~matplotlib.axes.Axes.set_prop_cycle` for more info on cyclers.
         Also see the `line style reference \
-<https://matplotlib.org/gallery/lines_bars_and_markers/line_styles_reference.html>`__,
+<https://matplotlib.org/2.2.5/gallery/lines_bars_and_markers/line_styles_reference.html>`__,
         the `marker reference \
-<https://matplotlib.org/3.1.0/gallery/lines_bars_and_markers/marker_reference.html>`__,
+<https://matplotlib.org/stable/gallery/lines_bars_and_markers/marker_reference.html>`__,
         and the `custom dashes reference \
-<https://matplotlib.org/3.1.0/gallery/lines_bars_and_markers/line_demo_dash_control.html>`__.
+<https://matplotlib.org/stable/gallery/lines_bars_and_markers/line_demo_dash_control.html>`__.
 
     Other parameters
     ----------------
@@ -771,9 +771,8 @@ def Norm(norm, *args, **kwargs):
     """
     Return an arbitrary `~matplotlib.colors.Normalize` instance. Used to
     interpret the `norm` and `norm_kw` arguments when passed to any plotting
-    method wrapped by `~proplot.axes.apply_cmap`. See
-    `this tutorial \
-<https://matplotlib.org/tutorials/colors/colormapnorms.html>`__
+    method wrapped by `~proplot.axes.apply_cmap`. See `this tutorial \
+<https://matplotlib.org/stable/tutorials/colors/colormapnorms.html>`__
     for more info.
 
     Parameters

--- a/proplot/demos.py
+++ b/proplot/demos.py
@@ -287,7 +287,7 @@ def show_channels(
     Show how arbitrary colormap(s) vary with respect to the hue, chroma,
     luminance, HSL saturation, and HPL saturation channels, and optionally
     the red, blue and green channels. Adapted from `this example \
-<https://matplotlib.org/3.1.0/tutorials/colors/colormaps.html#lightness-of-matplotlib-colormaps>`__.
+<https://matplotlib.org/stable/tutorials/colors/colormaps.html#lightness-of-matplotlib-colormaps>`__.
 
     Parameters
     ----------
@@ -665,7 +665,7 @@ def show_cmaps(*args, **kwargs):
     """
     Generate a table of the registered colormaps or the input colormaps
     categorized by source. Adapted from `this example \
-<http://matplotlib.org/examples/color/colormaps_reference.html>`__.
+<http://matplotlib.org/stable/gallery/color/colormap_reference.html>`__.
 
     Parameters
     ----------
@@ -712,7 +712,7 @@ def show_cycles(*args, **kwargs):
     """
     Generate a table of registered color cycles or the input color cycles
     categorized by source. Adapted from `this example \
-<http://matplotlib.org/examples/color/colormaps_reference.html>`__.
+<http://matplotlib.org/stable/gallery/color/colormap_reference.html>`__.
 
     Parameters
     ----------
@@ -762,14 +762,14 @@ def show_fonts(
         The font name(s). If none are provided and the `family` keyword
         argument was not provided, the *available* :rcraw:`font.sans-serif`
         fonts and the fonts in your ``.proplot/fonts`` folder are shown.
-    family : {'serif', 'sans-serif', 'monospace', 'cursive', 'fantasy', \
-'tex-gyre'}, optional
+    family \
+: {'serif', 'sans-serif', 'monospace', 'cursive', 'fantasy', 'tex-gyre'}, optional
         If provided, the *available* fonts in the corresponding families
         are shown. The fonts belonging to these families are listed under the
         :rcraw:`font.serif`, :rcraw:`font.sans-serif`, :rcraw:`font.monospace`,
-        :rcraw:`font.cursive`, and :rcraw:`font.fantasy` settings. The special
-        family ``'tex-gyre'`` draws the `TeX Gyre \
-<http://www.gust.org.pl/projects/e-foundry/tex-gyre>`__ fonts.
+        :rcraw:`font.cursive`, and :rcraw:`font.fantasy` settings. The
+        family ``'tex-gyre'`` draws the
+        `TeX Gyre <http://www.gust.org.pl/projects/e-foundry/tex-gyre>`__ fonts.
     text : str, optional
         The sample text. The default sample text includes the Latin letters,
         Greek letters, Arabic numerals, and some simple mathematical symbols.

--- a/proplot/demos.py
+++ b/proplot/demos.py
@@ -244,10 +244,11 @@ def _draw_bars(
             cmapdict.pop(cat)
 
     # Draw figure
+    # Allocate two colorbar widths for each title of sections
     naxs = 2 * len(cmapdict) + sum(map(len, cmapdict.values()))
     fig, axs = ui.subplots(
         nrows=naxs, refwidth=length, refheight=width,
-        share=0, hspace=0.03,
+        share=0, hspace='2pt', top='-1em',
     )
     iax = -1
     nheads = nbars = 0  # for deciding which axes to plot in
@@ -327,8 +328,8 @@ def show_channels(
         array += [np.array([4, 4, 5, 5, 6, 6]) + 2 * int(saturation)]
         labels += ('Red', 'Green', 'Blue')
     fig, axs = ui.subplots(
-        array=array, span=False, share=1,
-        refwidth=refwidth, innerpad='1em',
+        array=array, refwidth=refwidth, wratios=(1.5, 1, 1, 1, 1, 1.5),
+        share=1, span=False, innerpad='1em',
     )
     # Iterate through colormaps
     mc = ms = mp = 0

--- a/proplot/demos.py
+++ b/proplot/demos.py
@@ -244,7 +244,7 @@ def _draw_bars(
             cmapdict.pop(cat)
 
     # Draw figure
-    naxs = len(cmapdict) + sum(map(len, cmapdict.values()))
+    naxs = 2 * len(cmapdict) + sum(map(len, cmapdict.values()))
     fig, axs = ui.subplots(
         nrows=naxs, refwidth=length, refheight=width,
         share=0, hspace=0.03,
@@ -257,11 +257,10 @@ def _draw_bars(
             iax += 1
             if imap + nheads + nbars > naxs:
                 break
-            ax = axs[iax]
             if imap == 0:  # allocate this axes for title
-                iax += 1
-                ax.set_visible(False)
-                ax = axs[iax]
+                iax += 2
+                axs[iax - 2:iax].set_visible(False)
+            ax = axs[iax]
             cmap = database[name]
             if N is not None:
                 cmap = cmap.copy(N=N)

--- a/proplot/figure.py
+++ b/proplot/figure.py
@@ -206,15 +206,15 @@ class Figure(mfigure.Figure):
             your figure will have 1 ylabel instead of 9.
         alignx, aligny, align : bool or {0, 1}, optional
             Whether to `align axis labels \
-<https://matplotlib.org/3.1.1/gallery/subplots_axes_and_figures/align_labels_demo.html>`__
+<https://matplotlib.org/stable/gallery/subplots_axes_and_figures/align_labels_demo.html>`__
             for the *x* axis, *y* axis, or both axes. Only has an effect when `spanx`,
             `spany`, or `span` are ``False``. Default is :rc:`subplots.align`.
         mathtext_fallback : bool or str, optional
             Figure-specific application of the :rc:`mathtext.fallback` property.
             If ``True`` or string, unavailable glyphs are replaced with a glyph from a
             fallback font (Computer Modern by default). Otherwise, they are replaced
-            with the "¤" dummy character. See `mathtext \
-<https://matplotlib.org/3.1.1/tutorials/text/mathtext.html#custom-fonts>`__
+            with the "¤" dummy character. See this `mathtext tutorial \
+<https://matplotlib.org/stable/tutorials/text/mathtext.html#custom-fonts>`__
             for details.
         gridspec_kw, subplots_kw, subplots_orig_kw
             Keywords used for initializing the main gridspec, for initializing

--- a/proplot/internals/docstring.py
+++ b/proplot/internals/docstring.py
@@ -9,10 +9,12 @@ snippets = {}
 
 
 def add_snippets(func):
-    """Decorator that dedents docstrings with `inspect.getdoc` and adds
+    """
+    Decorator that dedents docstrings with `inspect.getdoc` and adds
     un-indented snippets from the global `snippets` dictionary. This function
     uses ``%(name)s`` substitution rather than `str.format` substitution so
-    that the `snippets` keys can be invalid variable names."""
+    that the `snippets` keys can be invalid variable names.
+    """
     func.__doc__ = inspect.getdoc(func)
     if func.__doc__:
         func.__doc__ %= {key: value.strip() for key, value in snippets.items()}

--- a/proplot/internals/rcsetup.py
+++ b/proplot/internals/rcsetup.py
@@ -244,14 +244,14 @@ _rc_matplotlib_default = {
 _addendum_units = ' Interpreted by `~proplot.utils.units`.'
 _addendum_fonts = (
     ' (see `this list of valid font sizes '
-    '<https://matplotlib.org/3.1.1/tutorials/text/text_props.html#default-font>`__).'
+    '<https://matplotlib.org/stable/tutorials/text/text_props.html#default-font>`__).'
 )
 _rc_proplot = {
     # Stylesheet
     'style': (
         None,
         'The default matplotlib `stylesheet '
-        '<https://matplotlib.org/3.2.1/gallery/style_sheets/style_sheets_reference.html>`__ '  # noqa: E501
+        '<https://matplotlib.org/stable/gallery/style_sheets/style_sheets_reference.html>`__ '  # noqa: E501
         'name. If ``None``, a custom proplot style is used. '
         "If ``'default'``, the default matplotlib style is used."
     ),
@@ -769,7 +769,7 @@ _rc_proplot = {
     'subplots.align': (
         False,
         'Whether to align axis labels during draw. See `aligning labels '
-        '<https://matplotlib.org/3.1.1/gallery/subplots_axes_and_figures/align_labels_demo.html>`__.'  # noqa: E501
+        '<https://matplotlib.org/stable/gallery/subplots_axes_and_figures/align_labels_demo.html>`__.'  # noqa: E501
     ),
     'subplots.innerpad': (
         '1em',

--- a/proplot/internals/warnings.py
+++ b/proplot/internals/warnings.py
@@ -40,14 +40,12 @@ def _deprecate_getter_setter(version, property):
             f'{type(self).__name__}.{property} instead.'
         )
         return getattr(self, '_' + property)
-
-    def setter(self, value):
+    def setter(self, value):  # noqa: E306
         _warn_proplot(
             f'set_{property}() was deprecated in {version}. The property is '
             f'now read-only.'
         )
         return
-
     getter.__name__ = f'get_{property}'
     setter.__name__ = f'set_{property}'
 
@@ -61,7 +59,6 @@ def _rename_objs(version, **kwargs):
     """
     wrappers = []
     for old_name, func_or_class in kwargs.items():
-
         def wrapper(*args, old_name=old_name, func_or_class=func_or_class, **kwargs):
             new_name = func_or_class.__name__
             _warn_proplot(
@@ -69,10 +66,8 @@ def _rename_objs(version, **kwargs):
                 f'removed in the next major release. Please use {new_name!r} instead.'
             )
             return func_or_class(*args, **kwargs)
-
         wrapper.__name__ = old_name
         wrappers.append(wrapper)
-
     if len(wrappers) == 1:
         return wrappers[0]
     else:

--- a/proplot/scale.py
+++ b/proplot/scale.py
@@ -236,10 +236,9 @@ class SymmetricalLogScale(_Scale, mscale.SymmetricalLogScale):
             of the base. For example, ``subs=(1, 2, 5)`` draws ticks on 1, 2,
             5, 10, 20, 50, 100, 200, 500, etc. The default is
             ``subs=numpy.arange(1, 10)``.
-        basex, basey, linthreshx, linthreshy, linscalex, linscaley, \
-subsx, subsy
-            Aliases for the above keywords. These used to be conditional
-            on the *name* of the axis.
+        basex, basey, linthreshx, linthreshy, linscalex, linscaley, subsx, subsy
+            Aliases for the above keywords. These keywords used to be
+            conditional on the name of the axis.
         """
         keys = ('base', 'linthresh', 'linscale', 'subs')
         super().__init__(**_parse_logscale_args(*keys, **kwargs))
@@ -263,16 +262,16 @@ class FuncScale(_Scale, mscale.ScaleBase):
         """
         Parameters
         ----------
-        arg : function, (function, function), or \
-`~matplotlib.scale.ScaleBase`
+        arg : function, (function, function), or `~matplotlib.scale.ScaleBase`
             The transform used to translate units from the parent axis to
             the secondary axis. Input can be as follows:
 
             * A single function that accepts a number and returns some
               transformation of that number. If you do not provide the
-              inverse, the function must be
-              `linear <https://en.wikipedia.org/wiki/Linear_function>`__ or \
-`involutory <https://en.wikipedia.org/wiki/Involution_(mathematics)>`__.
+              inverse, the function must be `linear \
+<https://en.wikipedia.org/wiki/Linear_function>`__
+              or `involutory \
+<https://en.wikipedia.org/wiki/Involution_(mathematics)>`__.
               For example, to convert Kelvin to Celsius, use
               ``ax.dual%(x)s(lambda x: x - 273.15)``. To convert kilometers
               to meters, use ``ax.dual%(x)s(lambda x: x*1e3)``.
@@ -298,8 +297,7 @@ class FuncScale(_Scale, mscale.ScaleBase):
             The default major and minor locator. By default these are
             borrowed from `transform`. If `transform` is not an axis scale,
             they are the same as `~matplotlib.scale.LinearScale`.
-        major_formatter, minor_formatter : `~matplotlib.ticker.Formatter`, \
-optional
+        major_formatter, minor_formatter : `~matplotlib.ticker.Formatter`, optional
             The default major and minor formatter. By default these are
             borrowed from `transform`. If `transform` is not an axis scale,
             they are the same as `~matplotlib.scale.LinearScale`.
@@ -578,10 +576,9 @@ class InvertedExpTransform(mtransforms.Transform):
 
 class MercatorLatitudeScale(_Scale, mscale.ScaleBase):
     """
-    Axis scale that transforms coordinates as with latitude in the
-    `Mercator projection <http://en.wikipedia.org/wiki/Mercator_projection>`__.
-    Adapted from `this matplotlib example \
-<https://matplotlib.org/examples/api/custom_scale_example.html>`__.
+    Axis scale that is linear in the `Mercator projection latitude \
+<http://en.wikipedia.org/wiki/Mercator_projection>`__. Adapted from `this example \
+<https://matplotlib.org/2.0.2/examples/api/custom_scale_example.html>`__.
     The scale function is as follows:
 
     .. math::
@@ -669,9 +666,9 @@ class InvertedMercatorLatitudeTransform(mtransforms.Transform):
 
 class SineLatitudeScale(_Scale, mscale.ScaleBase):
     r"""
-    Axis scale that is linear in the *sine* of *x*. The axis limits are
-    constrained to fall between ``-90`` and ``+90`` degrees. The scale
-    function is as follows:
+    Axis scale that is linear in the sine transformation of *x*. The axis
+    limits are constrained to fall between ``-90`` and ``+90`` degrees.
+    The scale function is as follows:
 
     .. math::
 

--- a/proplot/ui.py
+++ b/proplot/ui.py
@@ -283,8 +283,9 @@ def subplots(
         Passed to `~proplot.gridspec.GridSpec`, denotes the width of padding between
         the subplots and figure edge. Units are interpreted by `~proplot.utils.units`.
         By default, these are determined by the "tight layout" algorithm.
-    proj, projection : str, `cartopy.crs.Projection`, `~mpl_toolkits.basemap.Basemap`, \
-list thereof, or dict thereof, optional
+    proj, projection \
+: str, `cartopy.crs.Projection`, `~mpl_toolkits.basemap.Basemap`, list thereof, \
+or dict thereof, optional
         The map projection specification(s). If ``'cartesian'`` (the default), a
         `~proplot.axes.CartesianAxes` is created. If ``'polar'``, a
         `~proplot.axes.PolarAxes` is created. Otherwise, the argument is


### PR DESCRIPTION
Resolves #194 (and #229). This is another one of those big "refactor" PRs. There are already a couple of them in the recent commit history -- I've been trying to make `plot.py` more organized, modular, and, well... less of a clusterf*ck. This will be the final one before the imminent v0.7 release. Here are some notes:

* The canonical order for 1D plotting wrappers is now switched from `plot_specific_wrapper` --> `standardize_1d` -->  ... to `standardize_1d` --> `plot_specific_wrapper` --> ... . This way I don't have to individually parse positional arguments for each `plot_specific_wrapper`. Now, the `plot_specific_wrapper`s are all smaller -- they just add keywords and support `negpos` "negative-positive" plots. Previously I had to put wrappers *before* `standardize` to convert keywords like `x`, `ymin`, etc. to positional arguments, but now that is handled inside `standardize_1d`.
* The `standardize_1d` and `standardize_2d` functions now accept a `data` argument, just like many (all?) matplotlib commands. ProPlot previously disabled this feature. Now, you can use e.g. `ax.plot('x', 'y', data=pandas_dataframe)` or e.g. `ax.contourf('z', data=xarray_dataset)` and `standardize` will retrieve arrays from the dict-like containers. This is arguably a cleaner way to work with `DataFrame` and `DataArray` input.
* All "auto-formatting" is now done in `_auto_format_1d` and `_auto_format_2d` (from d3352720 on master). There is no longer "auto-formatting" of legends/colorbars in `apply_cmap` and `apply_cycle` -- the `_auto_format` functions just pass those funcs default keyword args. This also lets me enforce consistent type -- `_auto_format` always spits out numpy ndarrays or masked ndarrays. Makes the remaining wrappers much simpler. I also caught a few edge case bugs while refactoring this stuff.
* There are new plotting commands `plotx` and `scatterx`. They are the same as respective `plot` and `scatter` but positional input is either `command(x)` or `command(y, x)` and multiple columns of *x* coordinates are supported. This is analogous to `fill_betweenx`/`areax` and `barh`. This also permits "horizontal-direction" shading (resolves #194) without adding a bunch of keywords to `indicate_error`.
* Implementing separate `plot` and `plotx` functions let me impose "sticky edges" for line plots (a pet peeve of mine). Now, if you don't specify limits, the default limits of the *dependent* axis (x for `plot`, y for `plotx`) are drawn right up to the line edge rather than having padding. I find this is what I want 99% of the time. Without a dedicated `plotx`, it would be equally possible to have a `plot` where *y* is intended to be the "dependent" axis, so until now I couldn't implement this.
* The process of wrapping `barh` is *considerably* simplified. There are two possible workflows for implementing "horizontal" plotting commands:

  1. Wrap only e.g. `plot()`, have `plotx()` point to the wrapped `plot()` function, and have an undocumented `plot()` method on `base.Axes` (or add something to `cycle_changer`) that reverses positional arguments when it gets a keyword like `vert=False`.
  2. Wrap both `plot()` and `plotx()` with the usual `standardize_1d` --> ... chain, make their `plot_extras` wrappers point to a shared function, and have the `plotx()` method on `base.Axes` reverse the arguments.
 
  Previously I used the former approach for `barh` and latter approach for `fill_between`/`fill_betweenx` and `vlines`/`hlines`. Now I use the latter approach for everything -- it's much cleaner.


Originally I was thinking I'd need to implement "wrappers" on `base.Axes` for this system to be sustainable (#45). But I actually really like how `plot.py` has turned out... Perhaps in #45 (after v0.7) I will simply make the "wrapper" functions hidden and figure out a way to concatenate proplot/matplotlib docstrings on `base.Axes` instances (so that it's easier for users to learn ProPlot). But as far as additional refactoring goes, the current implementation isn't too bad.