### PR TITLE
Plot to pplt

### DIFF
--- a/docs/1dplots.py
+++ b/docs/1dplots.py
@@ -47,18 +47,18 @@
 # plotting method is called for each column of the array.
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
 
 N = 5
 state = np.random.RandomState(51423)
-with plot.rc.context({'axes.prop_cycle': plot.Cycle('Grays', N=N, left=0.3)}):
+with pplt.rc.context({'axes.prop_cycle': pplt.Cycle('Grays', N=N, left=0.3)}):
     # Sample data
     x = np.linspace(-5, 5, N)
     y = state.rand(N, 5)
 
     # Figure
-    fig, axs = plot.subplots(ncols=2, share=False)
+    fig, axs = pplt.subplots(ncols=2, share=False)
     axs.format(xlabel='xlabel', ylabel='ylabel')
     axs.format(suptitle='Standardized arguments demonstration')
 
@@ -148,16 +148,16 @@ df.index.name = 'date'
 df.columns.name = 'category'
 
 # %%
-import proplot as plot
-fig, axs = plot.subplots(ncols=2, refwidth=2.2, share=0)
+import proplot as pplt
+fig, axs = pplt.subplots(ncols=2, refwidth=2.2, share=0)
 axs.format(suptitle='Automatic subplot formatting')
 
 # Plot DataArray
-cycle = plot.Cycle('dark blue', space='hpl', N=da.shape[1])
+cycle = pplt.Cycle('dark blue', space='hpl', N=da.shape[1])
 axs[0].scatter(da, cycle=cycle, lw=3, colorbar='ul', colorbar_kw={'locator': 20})
 
 # Plot Dataframe
-cycle = plot.Cycle('dark green', space='hpl', N=df.shape[1])
+cycle = pplt.Cycle('dark green', space='hpl', N=df.shape[1])
 axs[1].plot(df, cycle=cycle, lw=3, legend='uc')
 
 
@@ -174,7 +174,7 @@ axs[1].plot(df, cycle=cycle, lw=3, legend='uc')
 # with any plotting method wrapped by `~proplot.axes.apply_cycle`. `cycle` and
 # `cycle_kw` are passed to the `~proplot.constructor.Cycle`
 # :ref:`constructor function <why_constructor>`, and the resulting property cycle
-# is used for the plot. You can specify `cycle` once with 2D input data (in which case
+# is used for the pplt. You can specify `cycle` once with 2D input data (in which case
 # each column is plotted in succession according to the property cycle) or call a
 # plotting command multiple times with the same `cycle` argument each time (the
 # property cycle is not reset). For more information on property cycles, see the
@@ -182,7 +182,7 @@ axs[1].plot(df, cycle=cycle, lw=3, legend='uc')
 # <https://matplotlib.org/tutorials/intermediate/color_cycle.html#sphx-glr-tutorials-intermediate-color-cycle-py>`__.
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
 
 # Sample data
@@ -191,9 +191,9 @@ state = np.random.RandomState(51423)
 data1 = state.rand(M, N)
 data2 = state.rand(M, N) * 1.5
 
-with plot.rc.context({'lines.linewidth': 3}):
+with pplt.rc.context({'lines.linewidth': 3}):
     # Figure
-    fig, axs = plot.subplots(ncols=2, refwidth=2.2, span=False)
+    fig, axs = pplt.subplots(ncols=2, refwidth=2.2, span=False)
     axs.format(xlabel='xlabel', ylabel='ylabel', suptitle='Local property cycles demo')
 
     # Use property cycle for columns of 2D input data
@@ -238,10 +238,10 @@ with plot.rc.context({'lines.linewidth': 3}):
 # (the default colors are :rc:`negcolor` and :rc:`poscolor`).
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
 state = np.random.RandomState(51423)
-fig, axs = plot.subplots(ncols=2, nrows=3, refwidth=2.2, share=1, span=False)
+fig, axs = pplt.subplots(ncols=2, nrows=3, refwidth=2.2, share=1, span=False)
 axs.format(suptitle='Line plots demo', xlabel='xlabel', ylabel='ylabel')
 
 # Vertical vs. horizontal
@@ -311,7 +311,7 @@ ax.format(title='Stem plot')
 # the keywords `smin` and `smax` (analogous to `vmin` and `vmax` used for colors).
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
 import pandas as pd
 
@@ -322,7 +322,7 @@ data = (state.rand(20, 4) - 0.5).cumsum(axis=0)
 data = pd.DataFrame(data, columns=pd.Index(['a', 'b', 'c', 'd'], name='label'))
 
 # Figure
-fig, axs = plot.subplots(ncols=2, nrows=2, refwidth=2.2, share=1, span=False)
+fig, axs = pplt.subplots(ncols=2, nrows=2, refwidth=2.2, share=1, span=False)
 axs.format(suptitle='Scatter plot demo')
 
 # Vertical vs. horizontal
@@ -385,7 +385,7 @@ axs.format(xlabel='xlabel', ylabel='ylabel')
 # the shading and axes edges by default.
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
 import pandas as pd
 
@@ -398,10 +398,10 @@ data = pd.DataFrame(
 )
 
 # Figure
-plot.rc.abc = True
-plot.rc.titleloc = 'l'
-plot.rc.abcstyle = 'a.'
-fig, axs = plot.subplots(nrows=2, refaspect=2, refwidth=4.8, share=0, hratios=(3, 2))
+pplt.rc.abc = True
+pplt.rc.titleloc = 'l'
+pplt.rc.abcstyle = 'a.'
+fig, axs = pplt.subplots(nrows=2, refaspect=2, refwidth=4.8, share=0, hratios=(3, 2))
 
 # Side-by-side bars
 ax = axs[0]
@@ -424,7 +424,7 @@ ax.format(title='Stacked')
 axs.format(grid=False)
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
 
 # Sample data
@@ -433,7 +433,7 @@ data = state.rand(5, 3).cumsum(axis=0)
 cycle = ('gray3', 'gray5', 'gray7')
 
 # Figure
-fig, axs = plot.subplots(ncols=2, refwidth=2.3, share=0)
+fig, axs = pplt.subplots(ncols=2, refwidth=2.3, share=0)
 axs.format(grid=False, xlabel='xlabel', ylabel='ylabel', suptitle='Area plot demo')
 
 # Overlaid area patches
@@ -453,7 +453,7 @@ ax.area(
 ax.format(title='Stack between columns')
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
 
 # Sample data
@@ -461,7 +461,7 @@ state = np.random.RandomState(51423)
 data = 4 * (state.rand(40) - 0.5)
 
 # Figure
-fig, axs = plot.subplots(nrows=2, refaspect=2, figwidth=5)
+fig, axs = pplt.subplots(nrows=2, refaspect=2, figwidth=5)
 axs.format(
     xmargin=0, xlabel='xlabel', ylabel='ylabel', grid=True,
     suptitle='Positive and negative colors demo',
@@ -477,7 +477,7 @@ axs[1].area(data, negpos=True, lw=0.5, edgecolor='k')
 axs[1].format(title='Area plot')
 
 # Reset title styles changed above
-plot.rc.reset()
+pplt.rc.reset()
 
 
 # %% [raw] raw_mimetype="text/restructuredtext"
@@ -503,7 +503,7 @@ plot.rc.reset()
 
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
 import pandas as pd
 
@@ -520,7 +520,7 @@ array_vertical = [[1], [2], [3]]
 array_horizontal = [[1, 1], [2, 3], [2, 3]]
 for name, array in zip(('horizontal', 'vertical'), (array_horizontal, array_vertical)):
     # Figure
-    fig, axs = plot.subplots(
+    fig, axs = pplt.subplots(
         array, refaspect=1.5, refwidth=4,
         share=0, hratios=(2, 1, 1)
     )
@@ -588,7 +588,7 @@ for name, array in zip(('horizontal', 'vertical'), (array_horizontal, array_vert
 # panels showing the marginal distributions.
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
 
 # Sample data
@@ -597,10 +597,10 @@ state = np.random.RandomState(51423)
 x = state.normal(size=(M, N)) + state.rand(M)[:, None] * np.arange(N) + 2 * np.arange(N)
 
 # Sample overlayed histograms
-fig, ax = plot.subplots(refwidth=4, refaspect=(3, 2))
+fig, ax = pplt.subplots(refwidth=4, refaspect=(3, 2))
 ax.format(suptitle='Overlaid histograms', xlabel='distribution', ylabel='count')
 ax.hist(
-    x, plot.arange(-3, 8, 0.2), alpha=0.7,
+    x, pplt.arange(-3, 8, 0.2), alpha=0.7,
     cycle=('blue9', 'gray9', 'orange9'), labels=list('abc'), legend='ul',
 )
 
@@ -608,10 +608,10 @@ ax.hist(
 N = 500
 x = state.normal(size=(N,))
 y = state.normal(size=(N,))
-bins = plot.arange(-3, 3, 0.25)
+bins = pplt.arange(-3, 3, 0.25)
 
 # Histogram with marginal distributions
-fig, axs = plot.subplots(ncols=2, refwidth=2.3)
+fig, axs = pplt.subplots(ncols=2, refwidth=2.3)
 axs.format(
     abc=True, abcstyle='A.', titleabove=True, title='Test',
     ylabel='y axis', suptitle='Histograms with marginal distributionss'
@@ -621,7 +621,7 @@ for ax, which, color in zip(axs, 'lr', ('blue9', 'orange9')):
         x, y, bins, vmin=0, vmax=10, levels=50,
         cmap=color, colorbar='b', colorbar_kw={'label': 'count'}
     )
-    color = plot.scale_luminance(color, 1.5)  # histogram colors
+    color = pplt.scale_luminance(color, 1.5)  # histogram colors
     side = ax.panel(which, space=0)
     side.hist(y, bins, color=color, vert=False)  # or orientation='horizontal'
     side.format(grid=False, xlocator=[], xreverse=(which == 'l'))
@@ -646,7 +646,7 @@ for ax, which, color in zip(axs, 'lr', ('blue9', 'orange9')):
 # `~xarray.DataArray` column labels or the input *x* coordinate labels.
 
 # %% tags=[]
-import proplot as plot
+import proplot as pplt
 import numpy as np
 import pandas as pd
 
@@ -659,7 +659,7 @@ data2 = state.rand(100, 7)
 data2 = pd.DataFrame(data2, columns=pd.Index(list('abcdefg'), name='label'))
 
 # Figure
-fig, axs = plot.subplots([[1, 1, 2, 2], [0, 3, 3, 0]], span=False)
+fig, axs = pplt.subplots([[1, 1, 2, 2], [0, 3, 3, 0]], span=False)
 axs.format(
     titleloc='l', abc=True, abcstyle='A.', grid=False,
     suptitle='Boxes and violins demo')
@@ -680,7 +680,7 @@ ax.format(title='Violin plots')
 
 # Boxes with different colors
 ax = axs[2]
-colors = plot.Colors('pastel2')  # list of colors from the cycle
+colors = pplt.Colors('pastel2')  # list of colors from the cycle
 ax.boxplot(data2, fillcolor=colors, orientation='horizontal')
 ax.format(title='Multiple colors', ymargin=0.15)
 
@@ -700,10 +700,10 @@ ax.format(title='Multiple colors', ymargin=0.15)
 # `~matplotlib.collections.LineCollection` returned by `~proplot.axes.Axes.parametric`.
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
 import pandas as pd
-fig, axs = plot.subplots(
+fig, axs = pplt.subplots(
     share=0, ncols=2, wratios=(2, 1),
     figwidth='16cm', refaspect=(2, 1)
 )

--- a/docs/1dplots.py
+++ b/docs/1dplots.py
@@ -223,7 +223,7 @@ with plot.rc.context({'lines.linewidth': 3}):
 # as *x* coordinates (with *y* coordinates inferred from the data),
 # and multiple arguments are interpreted as (*y*, *x*) pairs. This is
 # analogous to `~matplotlib.axes.Axes.barh` and `~matplotlib.axes.Axes.fill_betweenx`.
-# Also, the *x* extent of lines drawn with `~proplot.axes.Axes.plot` and
+# Also, the *x* extent of lines drawn with `~matplotlib.axes.Axes.plot` and
 # the *y* extent of lines drawn with `~proplot.axes.Axes.plotx` are now
 # "sticky", i.e. there is no padding between the lines and axes edges by default.
 #
@@ -374,15 +374,15 @@ axs.format(xlabel='xlabel', ylabel='ylabel')
 # The `~matplotlib.axes.Axes.fill_between` and `~matplotlib.axes.Axes.fill_betweenx`
 # commands are wrapped by `~proplot.axes.fill_between_extras` and
 # `~proplot.axes.fill_betweenx_extras`. They also have the optional shorthands
-# `~proplot.axes.Axes.area` and `~proplot.axes.Axes.areax`.
-# You can now *stack* or *overlay* columns of data by passing 2D arrays to
-# to these commands, just like in `pandas`_. You can also draw area plots that
-# change color when the fill boundaries cross each other by passing ``negpos=True``
-# (the default colors are :rc:`negcolor` and :rc:`poscolor`). The most common
-# use case for this is highlighting *negative* and *positive* areas with different
-# colors. Also, the *x* extent of shading drawn with `~proplot.axes.Axes.fill_between`
-# and the *y* extent of shading drawn with `~proplot.axes.Axes.fill_betweenx` is now
-# "sticky", i.e. there is no padding between the shading and axes edges by default.
+# `~proplot.axes.Axes.area` and `~proplot.axes.Axes.areax`. You can now *stack*
+# or *overlay* columns of data by passing 2D arrays to to these commands, just like in
+# `pandas`_. You can also draw area plots that change color when the fill boundaries
+# cross each other by passing ``negpos=True`` (the default colors are :rc:`negcolor`
+# and :rc:`poscolor`). The most common use case for this is highlighting *negative*
+# and *positive* areas with different colors. Also, the *x* extent of shading drawn
+# with `~matplotlib.axes.Axes.fill_between` and the *y* extent of shading drawn with
+# `~proplot.axes.Axes.fill_betweenx` is now "sticky", i.e. there is no padding between
+# the shading and axes edges by default.
 
 # %%
 import proplot as plot

--- a/docs/2dplots.py
+++ b/docs/2dplots.py
@@ -51,20 +51,20 @@
 # edges in the ``pcolor`` plots shown below.
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
 
 # Sample data
 state = np.random.RandomState(51423)
 x = y = np.array([-10, -5, 0, 5, 10])
-xedges = plot.edges(x)
-yedges = plot.edges(y)
+xedges = pplt.edges(x)
+yedges = pplt.edges(y)
 data = state.rand(y.size, x.size)  # "center" coordinates
 lim = (np.min(xedges), np.max(xedges))
 
-with plot.rc.context({'image.cmap': 'Grays', 'image.levels': 21}):
+with pplt.rc.context({'image.cmap': 'Grays', 'image.levels': 21}):
     # Figure
-    fig, axs = plot.subplots(ncols=2, nrows=2, refwidth=2.3, share=False)
+    fig, axs = pplt.subplots(ncols=2, nrows=2, refwidth=2.3, share=False)
     axs.format(
         xlabel='xlabel', ylabel='ylabel',
         xlim=lim, ylim=lim, xlocator=5, ylocator=5,
@@ -150,12 +150,12 @@ df.index.name = 'month'
 df.columns.name = 'variable (units)'
 
 # %%
-import proplot as plot
-fig, axs = plot.subplots(nrows=2, refwidth=2.5, share=0)
+import proplot as pplt
+fig, axs = pplt.subplots(nrows=2, refwidth=2.5, share=0)
 axs.format(toplabels=('Automatic subplot formatting',))
 
 # Plot DataArray
-cmap = plot.Colormap('PuBu', left=0.05)
+cmap = pplt.Colormap('PuBu', left=0.05)
 axs[0].contourf(da, cmap=cmap, colorbar='l', linewidth=0.7, color='k')
 axs[0].format(yreverse=True)
 
@@ -176,18 +176,18 @@ axs[1].format(xtickminor=False, yreverse=True)
 # You can do so using the `cmap` and `cmap_kw` arguments, available with any
 # plotting method wrapped by `~proplot.axes.apply_cmap`. `cmap` and `cmap_kw`
 # are passed to `~proplot.constructor.Colormap` and the resulting colormap is
-# used for the plot. For example, to create and apply a monochromatic colormap,
+# used for the pplt. For example, to create and apply a monochromatic colormap,
 # you can simply use ``cmap='color_name'``.
 #
 # The `~proplot.axes.apply_cmap` wrapper also
 # adds the `norm` and `norm_kw` arguments. They are passed to the
 # `~proplot.constructor.Norm` :ref:`constructor function <why_constructor>`,
-# and the resulting normalizer is used for the plot. For more information on colormaps
+# and the resulting normalizer is used for the pplt. For more information on colormaps
 # and normalizers, see the :ref:`colormaps section <ug_cmaps>` and `this matplotlib
 # tutorial <https://matplotlib.org/tutorials/colors/colormapnorms.html>`__.
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
 
 # Sample data
@@ -196,7 +196,7 @@ state = np.random.RandomState(51423)
 data = 11 ** (0.25 * np.cumsum(state.rand(N, N), axis=0))
 
 # Figure
-fig, axs = plot.subplots(ncols=2, refwidth=2.3, span=False)
+fig, axs = pplt.subplots(ncols=2, refwidth=2.3, span=False)
 axs.format(
     xlabel='xlabel', ylabel='ylabel', grid=True,
     suptitle='On-the-fly colormaps and normalizers'
@@ -217,7 +217,7 @@ axs[1].format(title='Logarithmic normalizer')
 # ------------------------
 #
 # The `~proplot.axes.apply_cmap` wrapper also "discretizes" the colormaps
-# used with every plot. This is done using `~proplot.colors.DiscreteNorm`,
+# used with every pplt. This is done using `~proplot.colors.DiscreteNorm`,
 # which converts data values into colormap colors by first (1) transforming
 # the data using an arbitrary *continuous* normalizer (e.g.,
 # `~matplotlib.colors.Normalize` or `~matplotlib.colors.LogNorm`), then
@@ -250,7 +250,7 @@ axs[1].format(title='Logarithmic normalizer')
 # the `proplot.utils.arange` and `proplot.utils.edges` commands may be useful.
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
 
 # Sample data
@@ -258,7 +258,7 @@ state = np.random.RandomState(51423)
 data = (state.normal(0, 1, size=(33, 33))).cumsum(axis=0).cumsum(axis=1)
 
 # Pcolor plot with and without distinct levels
-fig, axs = plot.subplots(ncols=2, refwidth=2.2)
+fig, axs = pplt.subplots(ncols=2, refwidth=2.2)
 axs.format(suptitle='DiscreteNorm with symmetric levels')
 for ax, n, mode, side in zip(axs, (200, 10), ('Ambiguous', 'Distinct'), 'lr'):
     m = ax.pcolor(data, cmap='spectral_r', levels=n, symmetric=True)
@@ -266,16 +266,16 @@ for ax, n, mode, side in zip(axs, (200, 10), ('Ambiguous', 'Distinct'), 'lr'):
     ax.colorbar(m, loc=side, locator=8)
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
 
 # Sample data
 state = np.random.RandomState(51423)
 data = (20 * (state.rand(20, 20) - 0.4).cumsum(axis=0).cumsum(axis=1)) % 360
-levels = plot.arange(0, 360, 45)
+levels = pplt.arange(0, 360, 45)
 
 # Figure
-fig, axs = plot.subplots(
+fig, axs = pplt.subplots(
     [[0, 1, 1, 0], [2, 3, 4, 5]],
     wratios=(1, 1, 1, 1), hratios=(1.5, 1),
     refwidth=2.4, refaspect=1, right='2em'
@@ -328,7 +328,7 @@ for ax, extend in zip(axs[1:], ('min', 'max', 'neither', 'both')):
 # with unusual statistical distributions.
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
 
 # Sample data
@@ -336,7 +336,7 @@ state = np.random.RandomState(51423)
 data = 10**(2 * state.rand(20, 20).cumsum(axis=0) / 7)
 
 # Linear segmented norm
-fig, axs = plot.subplots(ncols=2, refwidth=2.4)
+fig, axs = pplt.subplots(ncols=2, refwidth=2.4)
 ticks = [5, 10, 20, 50, 100, 200, 500, 1000]
 for i, (norm, title) in enumerate(zip(
     ('linear', 'segmented'),
@@ -351,7 +351,7 @@ for i, (norm, title) in enumerate(zip(
 axs.format(suptitle='Linear segmented normalizer demo')
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
 
 # Sample data
@@ -360,9 +360,9 @@ data1 = (state.rand(20, 20) - 0.485).cumsum(axis=1).cumsum(axis=0)
 data2 = (state.rand(20, 20) - 0.515).cumsum(axis=0).cumsum(axis=1)
 
 # Figure
-fig, axs = plot.subplots(nrows=2, ncols=2, refwidth=2.2, order='F')
+fig, axs = pplt.subplots(nrows=2, ncols=2, refwidth=2.2, order='F')
 axs.format(suptitle='Diverging normalizer demo')
-cmap = plot.Colormap('DryWet', cut=0.1)
+cmap = pplt.Colormap('DryWet', cut=0.1)
 
 # Diverging norms
 i = 0
@@ -373,7 +373,7 @@ for data, mode, fair, locator in zip(
     (3, 3),
 ):
     for fair in ('fair', 'unfair'):
-        norm = plot.Norm('diverging', fair=(fair == 'fair'))
+        norm = pplt.Norm('diverging', fair=(fair == 'fair'))
         ax = axs[i]
         m = ax.contourf(data, cmap=cmap, norm=norm)
         ax.colorbar(m, loc='b', locator=locator)
@@ -402,7 +402,7 @@ for data, mode, fair, locator in zip(
 # `~proplot.axes.apply_cmap` for details.
 
 # %%
-import proplot as plot
+import proplot as pplt
 import pandas as pd
 import numpy as np
 
@@ -412,7 +412,7 @@ data = state.rand(6, 6)
 data = pd.DataFrame(data, index=pd.Index(['a', 'b', 'c', 'd', 'e', 'f']))
 
 # Figure
-fig, axs = plot.subplots(
+fig, axs = pplt.subplots(
     [[1, 1, 2, 2], [0, 3, 3, 0]],
     refwidth=2.3, share=1, span=False,
 )
@@ -459,7 +459,7 @@ ax.format(title='Line contours with labels')
 # generally only be used with `~proplot.axes.CartesianAxes`.
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
 import pandas as pd
 
@@ -472,7 +472,7 @@ data[np.tril_indices(data.shape[0], -1)] = np.nan  # fill half with empty boxes
 data = pd.DataFrame(data, columns=list('abcdefghij'), index=list('abcdefghij'))
 
 # Covariance matrix plot
-fig, ax = plot.subplots(refwidth=4.5)
+fig, ax = pplt.subplots(refwidth=4.5)
 m = ax.heatmap(
     data, cmap='ColdHot', vmin=-1, vmax=1, N=100,
     lw=0.5, edgecolor='k', labels=True, labels_kw={'weight': 'bold'},

--- a/docs/2dplots.py
+++ b/docs/2dplots.py
@@ -242,7 +242,7 @@ axs[1].format(title='Logarithmic normalizer')
 # The colormap levels used with `~proplot.colors.DiscreteNorm` can be configured
 # with the `levels`, `values`, or `N` keywords. If you pass an integer to
 # one of these keywords, approximately that many boundaries are automatically
-# generated at "nice" intervals. The keywords `vmin`, `vmax, and `locator`
+# generated at "nice" intervals. The keywords `vmin`, `vmax`, and `locator`
 # control how the automatic intervals are chosen. You can also use
 # the `positive`, `negative`, and `symmetric` keywords to ensure that
 # automatically-generated levels are strictly positive, strictly negative,

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4,7 +4,7 @@ API reference
 
 Comprehensive documentation of ProPlot functions and classes. All of these
 objects are imported into the top-level namespace, so you can read the
-documentation within python sessions using ``help(plot.<function_or_class>)``.
+documentation within python sessions using ``help(pplt.<function_or_class>)``.
 
 Top-level functions
 ===================

--- a/docs/axis.py
+++ b/docs/axis.py
@@ -55,16 +55,16 @@
 # context.
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
 state = np.random.RandomState(51423)
-plot.rc.update(
-    facecolor=plot.scale_luminance('powderblue', 1.15),
+pplt.rc.update(
+    facecolor=pplt.scale_luminance('powderblue', 1.15),
     linewidth=1, fontsize=10,
     color='dark blue', suptitlecolor='dark blue',
     titleloc='upper center', titlecolor='dark blue', titleborder=False,
 )
-fig, axs = plot.subplots(nrows=8, refwidth=5, refaspect=(8, 1), share=0)
+fig, axs = pplt.subplots(nrows=8, refwidth=5, refaspect=(8, 1), share=0)
 axs.format(suptitle='Tick locators demo')
 
 # Step size for tick locations
@@ -105,7 +105,7 @@ axs[5].format(
     xformatter=[r'$\alpha$', r'$\beta$', r'$\gamma$', r'$\delta$', r'$\epsilon$'],
     title='IndexLocator',
 )
-plot.rc.reset()
+pplt.rc.reset()
 
 # Hide all ticks
 axs[6].format(
@@ -156,14 +156,14 @@ axs[7].format(
 # zero-trimming feature, set :rcraw:`formatter.zerotrim` to ``False``.
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
-plot.rc.update(
+pplt.rc.update(
     linewidth=1.2, fontsize=10, facecolor='gray0', figurefacecolor='gray2',
     color='gray8', gridcolor='gray8', titlecolor='gray8', suptitlecolor='gray8',
     titleloc='upper center', titleborder=False,
 )
-fig, axs = plot.subplots(nrows=9, refwidth=5, refaspect=(8, 1), share=0)
+fig, axs = pplt.subplots(nrows=9, refwidth=5, refaspect=(8, 1), share=0)
 
 # Scientific notation
 axs[0].format(xlim=(0, 1e20), xformatter='sci', title='SciFormatter')
@@ -205,14 +205,14 @@ axs[8].format(
     xformatter='{x:.1f}', title='StrMethodFormatter',
 )
 axs.format(ylocator='null', suptitle='Tick formatters demo')
-plot.rc.reset()
+pplt.rc.reset()
 
 # %%
-import proplot as plot
-plot.rc.linewidth = 2
-plot.rc.fontsize = 11
+import proplot as pplt
+pplt.rc.linewidth = 2
+pplt.rc.fontsize = 11
 locator = [0, 0.25, 0.5, 0.75, 1]
-fig, axs = plot.subplots(ncols=2, nrows=2, refwidth=1.5, share=0)
+fig, axs = pplt.subplots(ncols=2, nrows=2, refwidth=1.5, share=0)
 
 # Formatter comparison
 axs[0].format(
@@ -236,7 +236,7 @@ axs.format(
     ytickloc='both', yticklabelloc='both',
     titlepad='0.5em', suptitle='Default formatters demo'
 )
-plot.rc.reset()
+pplt.rc.reset()
 
 
 # %% [raw] raw_mimetype="text/restructuredtext"
@@ -257,14 +257,14 @@ plot.rc.reset()
 # details.
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
-plot.rc.update(
+pplt.rc.update(
     linewidth=1.2, fontsize=10, ticklenratio=0.7,
     figurefacecolor='w', facecolor='pastel blue',
     titleloc='upper center', titleborder=False,
 )
-fig, axs = plot.subplots(nrows=5, refwidth=6, refaspect=(8, 1), share=0)
+fig, axs = pplt.subplots(nrows=5, refwidth=6, refaspect=(8, 1), share=0)
 axs[:4].format(xrotation=0)  # no rotation for these examples
 
 # Default date locator
@@ -302,7 +302,7 @@ axs[4].format(
 axs.format(
     ylocator='null', suptitle='Datetime locators and formatters demo'
 )
-plot.rc.reset()
+pplt.rc.reset()
 
 
 # %% [raw] raw_mimetype="text/restructuredtext"
@@ -333,21 +333,21 @@ plot.rc.reset()
 # * While matplotlib axis scales must be instantiated with an
 #   `~matplotlib.axis.Axis` instance (for backward compatibility reasons),
 #   ProPlot axis scales can be instantiated without the axis instance (e.g.
-#   ``plot.LogScale()`` instead of ``plot.LogScale(ax.xaxis)``).
+#   ``pplt.LogScale()`` instead of ``pplt.LogScale(ax.xaxis)``).
 # * The default `subs` for the ``'symlog'`` axis scale is now ``np.arange(1, 10)``,
 #   and the default `linthresh` is now ``1``. Also the ``'log'`` and ``'symlog'``
 #   axis scales now accept the keywords `base`, `linthresh`, `linscale`, and
 #   `subs` rather than keywords with trailing ``x`` or ``y``.
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
 N = 200
 lw = 3
-plot.rc.update({
+pplt.rc.update({
     'linewidth': 1, 'ticklabelweight': 'bold', 'axeslabelweight': 'bold'
 })
-fig, axs = plot.subplots(ncols=2, nrows=2, refwidth=1.8, share=0)
+fig, axs = pplt.subplots(ncols=2, nrows=2, refwidth=1.8, share=0)
 axs.format(suptitle='Axis scales demo', ytickminor=True)
 
 # Linear and log scales
@@ -364,7 +364,7 @@ ax.plot(np.linspace(0, 1, N), np.linspace(-1000, 1000, N), lw=lw)
 ax = axs[3]
 ax.format(yscale='logit', ylabel='logit scale')
 ax.plot(np.linspace(0, 1, N), np.linspace(0.01, 0.99, N), lw=lw)
-plot.rc.reset()
+pplt.rc.reset()
 
 
 # %% [raw] raw_mimetype="text/restructuredtext"
@@ -385,9 +385,9 @@ plot.rc.reset()
 # :ref:`"dual" unit axes <ug_dual>`.
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
-fig, axs = plot.subplots(nrows=4, refaspect=(5, 1), figwidth=6, sharex=False)
+fig, axs = pplt.subplots(nrows=4, refaspect=(5, 1), figwidth=6, sharex=False)
 ax = axs[0]
 
 # Sample data
@@ -424,10 +424,10 @@ for ax, iargs, title, locator in zip(axs, args, titles, locators):
     )
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
-plot.rc.reset()
-fig, axs = plot.subplots(nrows=2, ncols=3, refwidth=1.7, share=0, order='F')
+pplt.rc.reset()
+fig, axs = pplt.subplots(nrows=2, ncols=3, refwidth=1.7, share=0, order='F')
 axs.format(
     toplabels=('Power scales', 'Exponential scales', 'Cartographic scales'),
 )
@@ -496,11 +496,11 @@ for ax, scale, color in zip(axs[4:], ('sine', 'mercator'), ('coral', 'sky blue')
 # `symlog scale <https://matplotlib.org/stable/gallery/scales/symlog_demo.html>`__.
 
 # %%
-import proplot as plot
-plot.rc.update({'grid.alpha': 0.4, 'linewidth': 1, 'grid.linewidth': 1})
-c1 = plot.scale_luminance('cerulean', 0.5)
-c2 = plot.scale_luminance('red', 0.5)
-fig, axs = plot.subplots(
+import proplot as pplt
+pplt.rc.update({'grid.alpha': 0.4, 'linewidth': 1, 'grid.linewidth': 1})
+c1 = pplt.scale_luminance('cerulean', 0.5)
+c2 = pplt.scale_luminance('red', 0.5)
+fig, axs = pplt.subplots(
     [[1, 1, 2, 2], [0, 3, 3, 0]],
     share=0, refaspect=2.2, refwidth=3
 )
@@ -533,14 +533,14 @@ ax.dualx(
     lambda x: x * 1e6,
     label='Joules', formatter='log', grid=True, color=c2, gridcolor=c2
 )
-plot.rc.reset()
+pplt.rc.reset()
 
 # %%
-import proplot as plot
-plot.rc.update({'grid.alpha': 0.4, 'linewidth': 1, 'grid.linewidth': 1})
-c1 = plot.scale_luminance('cerulean', 0.5)
-c2 = plot.scale_luminance('red', 0.5)
-fig, axs = plot.subplots(ncols=2, share=0, refaspect=0.4, refwidth=1.8)
+import proplot as pplt
+pplt.rc.update({'grid.alpha': 0.4, 'linewidth': 1, 'grid.linewidth': 1})
+c1 = pplt.scale_luminance('cerulean', 0.5)
+c2 = pplt.scale_luminance('red', 0.5)
+fig, axs = pplt.subplots(ncols=2, share=0, refaspect=0.4, refwidth=1.8)
 axs.format(suptitle='Duplicate axes with special transformations')
 
 # Pressure as the linear scale, height on opposite axis (scale height 7km)
@@ -562,15 +562,15 @@ ax.format(
 ax.dualy(
     'pressure', label='pressure (hPa)', locator=100, color=c1, gridcolor=c1, grid=True,
 )
-plot.rc.reset()
+pplt.rc.reset()
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
-plot.rc.margin = 0
-c1 = plot.scale_luminance('cerulean', 0.5)
-c2 = plot.scale_luminance('red', 0.5)
-fig, ax = plot.subplots(refaspect=(3, 1), figwidth=6)
+pplt.rc.margin = 0
+c1 = pplt.scale_luminance('cerulean', 0.5)
+c2 = pplt.scale_luminance('red', 0.5)
+fig, ax = pplt.subplots(refaspect=(3, 1), figwidth=6)
 
 # Sample data
 cutoff = 1 / 5
@@ -589,4 +589,4 @@ ax.format(
 ax = ax.dualx(
     'inverse', locator='log', locator_kw={'subs': (1, 2, 5)}, label='period (days)'
 )
-plot.rc.reset()
+pplt.rc.reset()

--- a/docs/basics.py
+++ b/docs/basics.py
@@ -85,7 +85,7 @@
 #    column share the same axis limits, scales, ticks, and labels. This is often
 #    convenient, but may be annoying for some users. To keep this feature turned off,
 #    simply :ref:`change the default settings <ug_rc>` with e.g.
-#    ``plot.rc.update(share=False, span=False)``. See the
+#    ``pplt.rc.update(share=False, span=False)``. See the
 #    :ref:`axis-sharing section <ug_share>` for details.
 
 # %%
@@ -96,16 +96,16 @@ data = 2 * (state.rand(100, 5) - 0.5).cumsum(axis=0)
 
 # %%
 # Single subplot
-import proplot as plot
-fig, ax = plot.subplots()
+import proplot as pplt
+fig, ax = pplt.subplots()
 ax.plot(data, lw=2)
 ax.format(suptitle='Single subplot', xlabel='x axis', ylabel='y axis')
 
 
 # %%
 # Simple subplot grid
-import proplot as plot
-fig, axs = plot.subplots(ncols=2)
+import proplot as pplt
+fig, axs = pplt.subplots(ncols=2)
 axs[0].plot(data, lw=2)
 axs[0].format(xticks=20, xtickminor=False)
 axs.format(
@@ -116,12 +116,12 @@ axs.format(
 
 # %%
 # Complex grid
-import proplot as plot
+import proplot as pplt
 array = [  # the "picture" (0 == nothing, 1 == subplot A, 2 == subplot B, etc.)
     [1, 1, 2, 2],
     [0, 3, 3, 0],
 ]
-fig, axs = plot.subplots(array, refwidth=1.8)
+fig, axs = pplt.subplots(array, refwidth=1.8)
 axs.format(
     abc=True, abcloc='ul', suptitle='Complex subplot grid',
     xlabel='xlabel', ylabel='ylabel'
@@ -131,14 +131,14 @@ axs[2].plot(data, lw=2)
 
 # %%
 # Really complex grid
-import proplot as plot
+import proplot as pplt
 array = [  # the "picture" (1 == subplot A, 2 == subplot B, etc.)
     [1, 1, 2],
     [1, 1, 6],
     [3, 4, 4],
     [3, 5, 5],
 ]
-fig, axs = plot.subplots(array, figwidth=5, span=False)
+fig, axs = pplt.subplots(array, figwidth=5, span=False)
 axs.format(
     suptitle='Really complex subplot grid',
     xlabel='xlabel', ylabel='ylabel', abc=True
@@ -170,7 +170,7 @@ axs[0].plot(data, lw=2)
 
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
 
 # Sample data
@@ -179,8 +179,8 @@ state = np.random.RandomState(51423)
 data = N + (state.rand(N, N) - 0.55).cumsum(axis=0).cumsum(axis=1)
 
 # Example plots
-cycle = plot.Cycle('greys', left=0.2, N=5)
-fig, axs = plot.subplots(ncols=2, nrows=2, figwidth=5, share=0)
+cycle = pplt.Cycle('greys', left=0.2, N=5)
+fig, axs = pplt.subplots(ncols=2, nrows=2, figwidth=5, share=0)
 axs[0].plot(data[:, :5], linewidth=2, linestyle='--', cycle=cycle)
 axs[1].scatter(data[:, :5], marker='x', cycle=cycle)
 axs[2].pcolormesh(data, cmap='greys')
@@ -240,9 +240,9 @@ fig.colorbar(m, loc='b', label='label')
 # efficiently customize your plots.
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
-fig, axs = plot.subplots(ncols=2, nrows=2, share=0, tight=True, refwidth=2)
+fig, axs = pplt.subplots(ncols=2, nrows=2, share=0, tight=True, refwidth=2)
 state = np.random.RandomState(51423)
 N = 60
 x = np.linspace(1, 10, N)
@@ -258,7 +258,7 @@ axs.format(
     xlabel='x-axis', ylabel='y-axis',
     xscale='log',
     xlim=(1, 10), xticks=1,
-    ylim=(-3, 3), yticks=plot.arange(-3, 3),
+    ylim=(-3, 3), yticks=pplt.arange(-3, 3),
     yticklabels=('a', 'bb', 'c', 'dd', 'e', 'ff', 'g'),
     ytickloc='both', yticklabelloc='both',
     xtickdir='inout', xtickminor=False, ygridminor=True,
@@ -284,7 +284,7 @@ axs.format(
 #   The default order can be switched from row-major to column-major by passing
 #   ``order='F'`` to `~proplot.ui.subplots`.
 # * When it is singleton, `~proplot.ui.SubplotsContainer` behaves like a
-#   scalar. So when you make a single axes with ``fig, axs = plot.subplots()``,
+#   scalar. So when you make a single axes with ``fig, axs = pplt.subplots()``,
 #   ``axs[0].method(...)`` is equivalent to ``axs.method(...)``.
 #
 # `~proplot.ui.SubplotsContainer` is especially useful because it lets you call
@@ -294,10 +294,10 @@ axs.format(
 # several subplots at once.
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
 state = np.random.RandomState(51423)
-fig, axs = plot.subplots(ncols=4, nrows=4, refwidth=1.2)
+fig, axs = pplt.subplots(ncols=4, nrows=4, refwidth=1.2)
 axs.format(
     xlabel='xlabel', ylabel='ylabel', suptitle='SubplotsContainer demo',
     grid=False, xlim=(0, 50), ylim=(-4, 4)
@@ -339,20 +339,20 @@ for ax in axs[1:, 1:]:
 
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
 
 # Update global settings in several different ways
-plot.rc.cycle = 'colorblind'
-plot.rc.color = 'gray6'
-plot.rc.update({'fontname': 'Source Sans Pro', 'fontsize': 11})
-plot.rc['figure.facecolor'] = 'gray3'
-plot.rc.axesfacecolor = 'gray4'
-# plot.rc.save()  # save the current settings to ~/.proplotrc
+pplt.rc.cycle = 'colorblind'
+pplt.rc.color = 'gray6'
+pplt.rc.update({'fontname': 'Source Sans Pro', 'fontsize': 11})
+pplt.rc['figure.facecolor'] = 'gray3'
+pplt.rc.axesfacecolor = 'gray4'
+# pplt.rc.save()  # save the current settings to ~/.proplotrc
 
 # Apply settings to figure with context()
-with plot.rc.context({'suptitle.size': 13}, toplabelcolor='gray6', linewidth=1.5):
-    fig, axs = plot.subplots(ncols=2, figwidth=6, sharey=2, span=False)
+with pplt.rc.context({'suptitle.size': 13}, toplabelcolor='gray6', linewidth=1.5):
+    fig, axs = pplt.subplots(ncols=2, figwidth=6, sharey=2, span=False)
 
 # Plot lines
 N, M = 100, 6
@@ -376,20 +376,20 @@ ay.format(ycolor='red', linewidth=1.5, ylabel='secondary axis')
 ay.plot((state.rand(100) - 0.2).cumsum(), color='r', lw=3)
 
 # Reset persistent modifications from head of cell
-plot.rc.reset()
+pplt.rc.reset()
 
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
-# plot.rc.style = 'style'  # set the style everywhere
+# pplt.rc.style = 'style'  # set the style everywhere
 
 # Sample data
 state = np.random.RandomState(51423)
 data = state.rand(10, 5)
 
 # Set up figure
-fig, axs = plot.subplots(ncols=2, nrows=2, span=False, share=False)
+fig, axs = pplt.subplots(ncols=2, nrows=2, span=False, share=False)
 axs.format(suptitle='Stylesheets demo')
 styles = ('ggplot', 'seaborn', '538', 'bmh')
 

--- a/docs/colorbars_legends.py
+++ b/docs/colorbars_legends.py
@@ -64,10 +64,10 @@
 # `~proplot.axes.apply_cycle` wrappers.
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
-with plot.rc.context(abc=True):
-    fig, axs = plot.subplots(ncols=2, share=0)
+with pplt.rc.context(abc=True):
+    fig, axs = pplt.subplots(ncols=2, share=0)
 
 # Colorbars
 ax = axs[0]
@@ -90,9 +90,9 @@ ax.legend(hs, loc='ll', label='legend label')
 axs.format(xlabel='xlabel', ylabel='ylabel')
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
-fig, axs = plot.subplots(nrows=2, share=0, refwidth='55mm', panelpad='1em')
+fig, axs = pplt.subplots(nrows=2, share=0, refwidth='55mm', panelpad='1em')
 axs.format(suptitle='Stacked colorbars demo')
 state = np.random.RandomState(51423)
 N = 10
@@ -137,9 +137,9 @@ for j, ax in enumerate(axs):
 # or pass a tuple to draw it beside a range of rows or columns.
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
-fig, axs = plot.subplots(ncols=3, nrows=3, refwidth=1.4)
+fig, axs = pplt.subplots(ncols=3, nrows=3, refwidth=1.4)
 state = np.random.RandomState(51423)
 m = axs.pcolormesh(
     state.rand(20, 20), cmap='grays',
@@ -155,9 +155,9 @@ fig.colorbar(m, label='stacked colorbar', ticks=0.1, loc='b', minorticks=0.05)
 fig.colorbar(m, label='colorbar with length <1', ticks=0.1, loc='r', length=0.7)
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
-fig, axs = plot.subplots(
+fig, axs = pplt.subplots(
     ncols=2, nrows=2, refwidth=1.7,
     share=0, wspace=0.3, order='F'
 )
@@ -165,7 +165,7 @@ fig, axs = plot.subplots(
 # Plot data
 data = (np.random.rand(50, 50) - 0.1).cumsum(axis=0)
 m = axs[:2].contourf(data, cmap='grays', extend='both')
-colors = plot.Colors('grays', 5)
+colors = pplt.Colors('grays', 5)
 hs = []
 state = np.random.RandomState(51423)
 for abc, color in zip('ABCDEF', colors):
@@ -208,15 +208,15 @@ for ax, title in zip(
 # figure when its size is changed.
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
-fig, axs = plot.subplots(share=0, ncols=2, refwidth=2)
+fig, axs = pplt.subplots(share=0, ncols=2, refwidth=2)
 
 # Colorbars from lines
 ax = axs[0]
 state = np.random.RandomState(51423)
 data = 1 + (state.rand(12, 10) - 0.45).cumsum(axis=0)
-cycle = plot.Cycle('algae')
+cycle = pplt.Cycle('algae')
 hs = ax.plot(
     data, lw=4, cycle=cycle, colorbar='lr',
     colorbar_kw={'length': '8em', 'label': 'from lines'}
@@ -230,7 +230,7 @@ axs.colorbar(
 ax = axs[1]
 m = ax.contourf(
     data.T, extend='both', cmap='algae',
-    levels=plot.arange(0, 3, 0.5)
+    levels=pplt.arange(0, 3, 0.5)
 )
 fig.colorbar(
     m, length=1, loc='r', label='inside ticks',
@@ -264,11 +264,11 @@ axs.format(
 # `order` keyword arg (default is row-major).
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
-plot.rc.cycle = '538'
+pplt.rc.cycle = '538'
 labels = ['a', 'bb', 'ccc', 'dddd', 'eeeee']
-fig, axs = plot.subplots(ncols=2, span=False, share=1, refwidth=2.3)
+fig, axs = pplt.subplots(ncols=2, span=False, share=1, refwidth=2.3)
 hs1, hs2 = [], []
 
 # On-the-fly legends

--- a/docs/colormaps.py
+++ b/docs/colormaps.py
@@ -85,8 +85,8 @@
 #    or color cycle. See `~proplot.colors.ColormapDatabase` for more info.
 
 # %%
-import proplot as plot
-fig, axs = plot.show_cmaps()
+import proplot as pplt
+fig, axs = pplt.show_cmaps()
 
 
 # %% [raw] raw_mimetype="text/restructuredtext"
@@ -132,16 +132,16 @@ fig, axs = plot.show_cmaps()
 
 # %%
 # Colorspace demo
-import proplot as plot
-fig, axs = plot.show_colorspaces(refwidth=1.6, luminance=50)
-fig, axs = plot.show_colorspaces(refwidth=1.6, saturation=60)
-fig, axs = plot.show_colorspaces(refwidth=1.6, hue=0)
+import proplot as pplt
+fig, axs = pplt.show_colorspaces(refwidth=1.6, luminance=50)
+fig, axs = pplt.show_colorspaces(refwidth=1.6, saturation=60)
+fig, axs = pplt.show_colorspaces(refwidth=1.6, hue=0)
 
 # %%
 # Compare colormaps
-import proplot as plot
+import proplot as pplt
 for cmaps in (('magma', 'rocket'), ('fire', 'dusk')):
-    fig, axs = plot.show_channels(
+    fig, axs = pplt.show_channels(
         *cmaps, refwidth=1.5, minhue=-180, maxsat=400, rgb=False
     )
 
@@ -187,13 +187,13 @@ for cmaps in (('magma', 'rocket'), ('fire', 'dusk')):
 # ``'hpl'`` colorspaces.
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
 state = np.random.RandomState(51423)
 data = state.rand(30, 30).cumsum(axis=1)
 
 # Initialize figure
-fig, axs = plot.subplots(ncols=2, nrows=2, refwidth=2, span=0)
+fig, axs = pplt.subplots(ncols=2, nrows=2, refwidth=2, span=0)
 axs.format(
     xticklabels='none',
     yticklabels='none',
@@ -202,21 +202,21 @@ axs.format(
 
 # Colormap from a color
 # The trailing '_r' makes the colormap go dark-to-light instead of light-to-dark
-cmap1 = plot.Colormap('prussian blue_r', l=100, name='Pacific', space='hpl')
+cmap1 = pplt.Colormap('prussian blue_r', l=100, name='Pacific', space='hpl')
 ax = axs[0]
 ax.format(title='From single named color')
 m = ax.contourf(data, cmap=cmap1)
 ax.colorbar(m, loc='b', ticks='none', label=cmap1.name)
 
 # Colormap from lists
-cmap2 = plot.Colormap(('maroon', 'light tan'), name='Heatwave')
+cmap2 = pplt.Colormap(('maroon', 'light tan'), name='Heatwave')
 ax = axs[1]
 ax.format(title='From list of colors')
 m = ax.contourf(data, cmap=cmap2)
 ax.colorbar(m, loc='b', ticks='none', label=cmap2.name)
 
 # Sequential colormap from channel values
-cmap3 = plot.Colormap(
+cmap3 = pplt.Colormap(
     h=('red', 'red-720'), s=(80, 20), l=(20, 100), space='hpl', name='CubeHelix'
 )
 ax = axs[2]
@@ -225,7 +225,7 @@ m = ax.contourf(data, cmap=cmap3)
 ax.colorbar(m, loc='b', ticks='none', label=cmap3.name)
 
 # Cyclic colormap from channel values
-cmap4 = plot.Colormap(
+cmap4 = pplt.Colormap(
     h=(0, 360), c=50, l=70, space='hcl', cyclic=True, name='Spectrum'
 )
 ax = axs[3]
@@ -234,8 +234,8 @@ m = ax.contourf(data, cmap=cmap4)
 ax.colorbar(m, loc='b', ticks='none', label=cmap4.name)
 
 # Display the channels
-fig, axs = plot.show_channels(cmap1, cmap2, refwidth=1.5, rgb=False)
-fig, axs = plot.show_channels(cmap3, cmap4, refwidth=1.5, rgb=False)
+fig, axs = pplt.show_channels(cmap1, cmap2, refwidth=1.5, rgb=False)
+fig, axs = pplt.show_channels(cmap3, cmap4, refwidth=1.5, rgb=False)
 
 
 # %% [raw] raw_mimetype="text/restructuredtext"
@@ -261,13 +261,13 @@ fig, axs = plot.show_channels(cmap3, cmap4, refwidth=1.5, rgb=False)
 # `~proplot.constructor.Colormap`.
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
 state = np.random.RandomState(51423)
 data = state.rand(30, 30).cumsum(axis=1)
 
 # Generate figure
-fig, axs = plot.subplots([[0, 1, 1, 0], [2, 2, 3, 3]], refwidth=2.4, span=False)
+fig, axs = pplt.subplots([[0, 1, 1, 0], [2, 2, 3, 3]], refwidth=2.4, span=False)
 axs.format(
     xlabel='xlabel', ylabel='ylabel',
     suptitle='Merging colormaps'
@@ -275,16 +275,16 @@ axs.format(
 
 # Diverging colormap example
 title1 = 'Diverging from two sequential maps'
-cmap1 = plot.Colormap('Blues4_r', 'Reds3', name='Diverging', save=True)
+cmap1 = pplt.Colormap('Blues4_r', 'Reds3', name='Diverging', save=True)
 
 # SciVisColor examples
 title2 = 'SciVisColor example with equal ratios'
-cmap2 = plot.Colormap(
+cmap2 = pplt.Colormap(
     'Greens1_r', 'Oranges1', 'Blues1_r', 'Blues6',
     name='SciVisColorEven', save=True
 )
 title3 = 'SciVisColor example'
-cmap3 = plot.Colormap(
+cmap3 = pplt.Colormap(
     'Greens1_r', 'Oranges1', 'Blues1_r', 'Blues6',
     ratios=(1, 3, 5, 10), name='SciVisColorUneven', save=True
 )
@@ -339,13 +339,13 @@ for ax, cmap, title in zip(axs, (cmap1, cmap2, cmap3), (title1, title2, title3))
 #   `HCL wizard <http://hclwizard.org:64230/hclwizard/>`__ "power" sliders.
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
 state = np.random.RandomState(51423)
 data = state.rand(40, 40).cumsum(axis=0)
 
 # Generate figure
-fig, axs = plot.subplots(
+fig, axs = pplt.subplots(
     [[0, 1, 1, 0], [2, 2, 3, 3]], refwidth=1.9, span=False,
 )
 axs.format(
@@ -370,24 +370,24 @@ for ax, coord in zip(axs, (None, 0.3, 0.7)):
 
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
 state = np.random.RandomState(51423)
 data = (state.rand(40, 40) - 0.5).cumsum(axis=0).cumsum(axis=1)
 
 # Generate figure
-fig, axs = plot.subplots(ncols=2, nrows=2, refwidth=1.7, span=False)
+fig, axs = pplt.subplots(ncols=2, nrows=2, refwidth=1.7, span=False)
 axs.format(
     xlabel='x axis', ylabel='y axis', xticklabels='none',
     suptitle='Modifying diverging colormaps',
 )
 
 # Cutting out central colors
-levels = plot.arange(-10, 10, 2)
+levels = pplt.arange(-10, 10, 2)
 for i, (ax, cut) in enumerate(zip(axs, (None, None, 0.2, -0.1))):
-    levels = plot.arange(-10, 10, 2)
+    levels = pplt.arange(-10, 10, 2)
     if i == 1 or i == 3:
-        levels = plot.edges(levels)
+        levels = pplt.edges(levels)
     if i < 2:
         title = 'Negative-positive cutoff' if i == 0 else 'Neutral-valued center'
         title = f'{title}\nlen(levels) = {len(levels)}'
@@ -402,13 +402,13 @@ for i, (ax, cut) in enumerate(zip(axs, (None, None, 0.2, -0.1))):
     )
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
 state = np.random.RandomState(51423)
 data = (state.rand(50, 50) - 0.48).cumsum(axis=0).cumsum(axis=1) % 30
 
 # Rotating cyclic colormaps
-fig, axs = plot.subplots(ncols=3, refwidth=1.7, span=False)
+fig, axs = pplt.subplots(ncols=3, refwidth=1.7, span=False)
 for ax, shift in zip(axs, (0, 90, 180)):
     m = ax.pcolormesh(data, cmap='romaO', cmap_kw={'shift': shift}, levels=12)
     ax.format(
@@ -418,16 +418,16 @@ for ax, shift in zip(axs, (0, 90, 180)):
     ax.colorbar(m, loc='b', locator='null')
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
 state = np.random.RandomState(51423)
 data = state.rand(20, 20).cumsum(axis=1)
 
 # Changing the colormap opacity
-fig, axs = plot.subplots(ncols=3, refwidth=1.7, span=False)
+fig, axs = pplt.subplots(ncols=3, refwidth=1.7, span=False)
 for ax, alpha in zip(axs, (1.0, 0.5, 0.0)):
     alpha = (alpha, 1.0)
-    cmap = plot.Colormap('batlow_r', alpha=alpha)
+    cmap = pplt.Colormap('batlow_r', alpha=alpha)
     m = ax.imshow(data, cmap=cmap, levels=10, extend='both')
     ax.colorbar(m, loc='b', locator='none')
     ax.format(
@@ -436,15 +436,15 @@ for ax, alpha in zip(axs, (1.0, 0.5, 0.0)):
     )
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
 state = np.random.RandomState(51423)
 data = state.rand(20, 20).cumsum(axis=1)
 
 # Changing the colormap gamma
-fig, axs = plot.subplots(ncols=3, refwidth=1.7, span=False)
+fig, axs = pplt.subplots(ncols=3, refwidth=1.7, span=False)
 for ax, gamma in zip(axs, (0.7, 1.0, 1.4)):
-    cmap = plot.Colormap('boreal', gamma=gamma)
+    cmap = pplt.Colormap('boreal', gamma=gamma)
     m = ax.pcolormesh(data, cmap=cmap, levels=10, extend='both')
     ax.colorbar(m, loc='b', locator='none')
     ax.format(

--- a/docs/colors.py
+++ b/docs/colors.py
@@ -48,8 +48,8 @@
 # example, ``'reddish'`` and ``'reddy'`` are changed to ``'red'``.
 
 # %%
-import proplot as plot
-fig, axs = plot.show_colors()
+import proplot as pplt
+fig, axs = pplt.show_colors()
 
 
 # %% [raw] raw_mimetype="text/restructuredtext"
@@ -73,12 +73,12 @@ fig, axs = plot.show_colors()
 
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
 
 # Figure
 state = np.random.RandomState(51423)
-fig, axs = plot.subplots(ncols=3, axwidth=2)
+fig, axs = pplt.subplots(ncols=3, axwidth=2)
 axs.format(
     suptitle='Modifying colors',
     toplabels=('Shifted hue', 'Scaled luminance', 'Scaled saturation'),
@@ -87,24 +87,24 @@ axs.format(
 )
 
 # Shifted hue
-with plot.rc.context({'legend.handlelength': 0}):
+with pplt.rc.context({'legend.handlelength': 0}):
     N = 50
     marker = 'o'
     for shift in (0, -60, 60):
         x, y = state.rand(2, N)
-        color = plot.shift_hue('grass', shift)
+        color = pplt.shift_hue('grass', shift)
         axs[0].scatter(x, y, marker=marker, c=color, legend='b', label=shift)
 
     # Scaled luminance
     for scale in (0.2, 1, 2):
         x, y = state.rand(2, N)
-        color = plot.scale_luminance('bright red', scale)
+        color = pplt.scale_luminance('bright red', scale)
         axs[1].scatter(x, y, marker=marker, c=color, legend='b', label=scale)
 
     # Scaled saturation
     for scale in (0, 1, 3):
         x, y = state.rand(2, N)
-        color = plot.scale_saturation('ocean blue', scale)
+        color = pplt.scale_saturation('ocean blue', scale)
         axs[2].scatter(x, y, marker=marker, c=color, legend='b', label=scale)
 
 # %% [raw] raw_mimetype="text/restructuredtext"
@@ -124,11 +124,11 @@ with plot.rc.context({'legend.handlelength': 0}):
 # the RGB or RGBA channel values.
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
 
 # Figure
-fig, axs = plot.subplots(nrows=2, share=0)
+fig, axs = pplt.subplots(nrows=2, share=0)
 axs.format(
     xformatter='null', yformatter='null', abc=True, abcloc='l', abcstyle='A.',
     suptitle='On-the-fly color selections'
@@ -137,7 +137,7 @@ axs.format(
 # Drawing from colormaps
 ax = axs[0]
 name = 'Deep'
-idxs = plot.arange(0, 1, 0.2)
+idxs = pplt.arange(0, 1, 0.2)
 state = np.random.RandomState(51423)
 state.shuffle(idxs)
 for idx in idxs:
@@ -146,7 +146,7 @@ for idx in idxs:
         data, lw=5, color=(name, idx),
         label=f'idx {idx:.1f}', legend='r', legend_kw={'ncols': 1}
     )
-ax.colorbar(plot.Colormap(name), loc='r', locator='none')
+ax.colorbar(pplt.Colormap(name), loc='r', locator='none')
 ax.format(title=f'Drawing from the {name} colormap', grid=True)
 
 # Drawing from color cycles
@@ -160,7 +160,7 @@ for idx in idxs:
         data, lw=5, color=(name, idx),
         label=f'idx {idx:.0f}', legend='r', legend_kw={'ncols': 1}
     )
-ax.colorbar(plot.Colormap(name), loc='r', locator='none')
+ax.colorbar(pplt.Colormap(name), loc='r', locator='none')
 ax.format(title=f'Drawing from the {name} cycle')
 
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -17,19 +17,19 @@ object:
 
 .. code-block:: python
 
-  import proplot as plot
-  plot.rc.name = value
-  plot.rc['name'] = value
-  plot.rc.update(name1=value1, name2=value2)
-  plot.rc.update({'name1': value1, 'name2': value2})
+  import proplot as pplt
+  pplt.rc.name = value
+  pplt.rc['name'] = value
+  pplt.rc.update(name1=value1, name2=value2)
+  pplt.rc.update({'name1': value1, 'name2': value2})
 
 To apply settings to a particular axes, pass the setting
 to the `~proplot.axes.Axes.format` command:
 
 .. code-block:: python
 
-  import proplot as plot
-  fig, ax = plot.subplots()
+  import proplot as pplt
+  fig, ax = pplt.subplots()
   ax.format(name1=value1, name2=value2)
   ax.format(rc_kw={'name1': value1, 'name2': value2})
 
@@ -38,11 +38,11 @@ to the `~proplot.config.RcConfigurator.context` command:
 
 .. code-block:: python
 
-   import proplot as plot
-   with plot.rc.context(name1=value1, name2=value2):
-       fig, ax = plot.subplots()
-   with plot.rc.context({'name1': value1, 'name2': value2}):
-       fig, ax = plot.subplots()
+   import proplot as pplt
+   with pplt.rc.context(name1=value1, name2=value2):
+       fig, ax = pplt.subplots()
+   with pplt.rc.context({'name1': value1, 'name2': value2}):
+       fig, ax = pplt.subplots()
 
 
 In all of these examples, if the setting name contains dots,
@@ -51,12 +51,12 @@ you can simply omit the dots. For example, to change the
 
 .. code-block:: python
 
-  import proplot as plot
+  import proplot as pplt
   # Apply globally
-  plot.rc.titleloc = value
-  plot.rc.update(titleloc=value)
+  pplt.rc.titleloc = value
+  pplt.rc.update(titleloc=value)
   # Apply locally
-  fig, ax = plot.subplots()
+  fig, ax = pplt.subplots()
   ax.format(titleloc=value)
 
 Matplotlib settings

--- a/docs/cycles.py
+++ b/docs/cycles.py
@@ -51,8 +51,8 @@
 # `~proplot.colors.Colors`.
 
 # %%
-import proplot as plot
-fig, axs = plot.show_cycles()
+import proplot as pplt
+fig, axs = pplt.show_cycles()
 
 
 # %% [raw] raw_mimetype="text/restructuredtext"
@@ -72,7 +72,7 @@ fig, axs = plot.show_cycles()
 # the :ref:`configuration guide <ug_config>`).
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
 
 # Sample data
@@ -82,8 +82,8 @@ kwargs = {'legend': 'b', 'labels': list('abcdef')}
 
 # Figure
 lw = 5
-plot.rc.cycle = '538'
-fig, axs = plot.subplots(ncols=3, refwidth=1.9)
+pplt.rc.cycle = '538'
+fig, axs = pplt.subplots(ncols=3, refwidth=1.9)
 axs.format(suptitle='Changing the color cycle')
 
 # Modify the default color cycle
@@ -116,7 +116,7 @@ ax.format(title='Multiple plot calls')
 # :ref:`constructor function <why_constructor>`. One great way to make cycles is by
 # sampling a colormap! Just pass the colormap name to `~proplot.constructor.Cycle`,
 # and optionally specify the number of samples you want to draw as the last positional
-# argument (e.g., ``plot.Cycle('Blues', 5)``).
+# argument (e.g., ``pplt.Cycle('Blues', 5)``).
 #
 # Positional arguments passed to `~proplot.constructor.Cycle` are interpreted
 # by the `~proplot.constructor.Colormap` constructor, and the resulting
@@ -130,9 +130,9 @@ ax.format(title='Multiple plot calls')
 # you to :ref:`generate colorbars from lists of artists <ug_cbars>`.
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
-fig, axs = plot.subplots(ncols=2, share=0, refwidth=2)
+fig, axs = pplt.subplots(ncols=2, share=0, refwidth=2)
 state = np.random.RandomState(51423)
 data = (20 * state.rand(10, 21) - 10).cumsum(axis=0)
 
@@ -145,7 +145,7 @@ ax.format(title='Cycle from a single color')
 
 # Cycle from registered colormaps
 ax = axs[1]
-cycle = plot.Cycle('blues', 'reds', 'oranges', 15, left=0.1)
+cycle = pplt.Cycle('blues', 'reds', 'oranges', 15, left=0.1)
 lines = ax.plot(data[:, :15], cycle=cycle, lw=5)
 fig.colorbar(lines, loc='b', col=2, values=np.arange(0, len(lines)), locator=2)
 fig.legend(lines, loc='b', col=2, labels=np.arange(0, len(lines)), ncols=4)
@@ -164,15 +164,15 @@ ax.format(
 # `~proplot.constructor.Cycle` can also generate cyclers that change
 # properties other than color. Below, a single-color dash style cycler is
 # constructed and applied to the axes locally. To apply it globally, simply
-# use ``plot.rc['axes.prop_cycle'] = cycle``.
+# use ``pplt.rc['axes.prop_cycle'] = cycle``.
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
 import pandas as pd
 
 # Cycle that loops through 'dashes' Line2D property
-cycle = plot.Cycle(lw=2, dashes=[(1, 0.5), (1, 1.5), (3, 0.5), (3, 1.5)])
+cycle = pplt.Cycle(lw=2, dashes=[(1, 0.5), (1, 1.5), (3, 0.5), (3, 1.5)])
 
 # Sample data
 state = np.random.RandomState(51423)
@@ -180,7 +180,7 @@ data = (state.rand(20, 4) - 0.5).cumsum(axis=0)
 data = pd.DataFrame(data, columns=pd.Index(['a', 'b', 'c', 'd'], name='label'))
 
 # Plot data
-fig, ax = plot.subplots(refwidth=2.5)
+fig, ax = pplt.subplots(refwidth=2.5)
 ax.format(suptitle='Plot without color cycle')
 obj = ax.plot(
     data, cycle=cycle, legend='ll',

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -7,7 +7,7 @@ What makes this project different?
 
 There is already a great matplotlib wrapper called
 `seaborn <https://seaborn.pydata.org/>`__. Also, `pandas
-<https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.plot.html>`__
+<https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.pplt.html>`__
 and `xarray <http://xarray.pydata.org/en/stable/plotting.html>`__
 both offer convenient matplotlib plotting commands.
 How does ProPlot compare against these tools?

--- a/docs/fonts.py
+++ b/docs/fonts.py
@@ -88,8 +88,8 @@
 #    because the RTD server includes this style.
 
 # %%
-import proplot as plot
-fig, axs = plot.show_fonts()
+import proplot as pplt
+fig, axs = pplt.show_fonts()
 
 
 # %% [raw] raw_mimetype="text/restructuredtext"

--- a/docs/insets_panels.py
+++ b/docs/insets_panels.py
@@ -42,7 +42,7 @@
 # adjusted by the tight layout algorithm.
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
 state = np.random.RandomState(51423)
 data = (state.rand(20, 20) - 0.48).cumsum(axis=1).cumsum(axis=0)
@@ -50,7 +50,7 @@ data = 10 * (data - data.min()) / (data.max() - data.min())
 
 # Stacked panels with outer colorbars
 for cbarloc, ploc in ('rb', 'br'):
-    fig, axs = plot.subplots(
+    fig, axs = pplt.subplots(
         refwidth=1.8, nrows=1, ncols=2,
         share=0, panelpad=0.1, includepanels=True
     )
@@ -91,8 +91,8 @@ for cbarloc, ploc in ('rb', 'br'):
     paxs.format(title='Stdev', **kwargs)
 
 # %%
-import proplot as plot
-fig, axs = plot.subplots(refwidth=1.5, nrows=2, ncols=2, share=0)
+import proplot as pplt
+fig, axs = pplt.subplots(refwidth=1.5, nrows=2, ncols=2, share=0)
 
 # Demonstrate that complex arrangements of panels does
 # not mess up subplot aspect ratios or tight layout spacing
@@ -127,7 +127,7 @@ for ax, side in zip(axs, 'tlbr'):
 # argument.
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
 
 # Sample data
@@ -137,7 +137,7 @@ x, y = np.arange(10), np.arange(10)
 data = state.rand(10, 10)
 
 # Plot data
-fig, ax = plot.subplots(refwidth=3)
+fig, ax = pplt.subplots(refwidth=3)
 m = ax.pcolormesh(data, cmap='Grays', levels=N)
 ax.colorbar(m, loc='b', label='label')
 ax.format(

--- a/docs/projections.py
+++ b/docs/projections.py
@@ -60,13 +60,13 @@
 # For details, see `proplot.axes.PolarAxes.format`.
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
 N = 200
 state = np.random.RandomState(51423)
 x = np.linspace(0, 2 * np.pi, N)
 y = 100 * (state.rand(N, 5) - 0.3).cumsum(axis=0) / N
-fig, axs = plot.subplots([[1, 1, 2, 2], [0, 3, 3, 0]], proj='polar')
+fig, axs = pplt.subplots([[1, 1, 2, 2], [0, 3, 3, 0]], proj='polar')
 axs.format(
     suptitle='Polar axes demo', linewidth=1, titlepad='1em',
     ticklabelsize=9, rlines=0.5, rlim=(0, 19),
@@ -78,14 +78,14 @@ for i in range(5):
 # Standard polar plot
 axs[0].format(
     title='Normal plot', thetaformatter='tau',
-    rlabelpos=225, rlines=plot.arange(5, 30, 5),
+    rlabelpos=225, rlines=pplt.arange(5, 30, 5),
     color='red8', tickpad='1em',
 )
 
 # Sector plot
 axs[1].format(
     title='Sector plot', thetadir=-1, thetalines=90, thetalim=(0, 270), theta0='N',
-    rlim=(0, 22), rlines=plot.arange(5, 30, 5),
+    rlim=(0, 22), rlines=pplt.arange(5, 30, 5),
 )
 
 # Annular plot
@@ -185,14 +185,14 @@ axs[2].format(
 # %%
 # Simple figure with just one projection
 
-# Option 1: Create a projection manually with plot.Proj()
+# Option 1: Create a projection manually with pplt.Proj()
 # immport proplot as plot
-# proj = plot.Proj('robin', lon_0=180)
-# fig, axs = plot.subplots(nrows=2, refwidth=3, proj=proj)
+# proj = pplt.Proj('robin', lon_0=180)
+# fig, axs = pplt.subplots(nrows=2, refwidth=3, proj=proj)
 
 # Option 2: Pass the name to 'proj' and keyword arguments to 'proj_kw'
-import proplot as plot
-fig, axs = plot.subplots(nrows=2, refwidth=3, proj='robin', proj_kw={'lon_0': 180})
+import proplot as pplt
+fig, axs = pplt.subplots(nrows=2, refwidth=3, proj='robin', proj_kw={'lon_0': 180})
 axs.format(
     suptitle='Figure with single projection',
     coast=True, latlines=30, lonlines=60,
@@ -200,8 +200,8 @@ axs.format(
 
 # %%
 # Complex figure with different projections
-import proplot as plot
-fig, axs = plot.subplots(
+import proplot as pplt
+fig, axs = pplt.subplots(
     ncols=2, nrows=3,
     hratios=(1, 1, 1.4),
     basemap=(False, True, False, True, False, True),  # cartopy column 1
@@ -215,7 +215,7 @@ axs.format(
     lonlabels='b', latlabels='r',  # or lonlabels=True, labels=True, etc.
 )
 axs[0, :].format(latlines=30, lonlines=60, labels=True)
-plot.rc.reset()
+pplt.rc.reset()
 
 
 # %% [raw] raw_mimetype="text/restructuredtext"
@@ -247,20 +247,20 @@ plot.rc.reset()
 # to ``True``. See the :ref:`next section <ug_geoformat>` for details.
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
 
 # Fake data with unusual longitude seam location and without coverage over poles
 offset = -40
-lon = plot.arange(offset, 360 + offset - 1, 60)
-lat = plot.arange(-60, 60 + 1, 30)
+lon = pplt.arange(offset, 360 + offset - 1, 60)
+lat = pplt.arange(-60, 60 + 1, 30)
 state = np.random.RandomState(51423)
 data = state.rand(len(lat), len(lon))
 
 # Plot data both without and with globe=True
 for globe in (False, True,):
     string = 'with' if globe else 'without'
-    fig, axs = plot.subplots(
+    fig, axs = pplt.subplots(
         ncols=2, nrows=2, refwidth=2.5,
         proj='kav7', basemap={(1, 3): False, (2, 4): True}
     )
@@ -303,8 +303,8 @@ for globe in (False, True,):
 # For details, see the `proplot.axes.GeoAxes.format` documentation.
 
 # %%
-import proplot as plot
-fig, axs = plot.subplots(
+import proplot as pplt
+fig, axs = pplt.subplots(
     [[1, 1, 2], [3, 3, 3]],
     refwidth=4, proj={1: 'eqearth', 2: 'ortho', 3: 'wintri'},
     wratios=(1, 1, 1.2), hratios=(1, 1.2),
@@ -367,12 +367,12 @@ ax.format(
 # projections with `format` after they have already been created.
 
 # %%
-import proplot as plot
+import proplot as pplt
 
 # Plate Carrée map projection
-plot.rc.reso = 'med'  # use higher res for zoomed in geographic features
-proj = plot.Proj('cyl', lonlim=(-20, 180), latlim=(-10, 50), basemap=True)
-fig, axs = plot.subplots(nrows=2, refwidth=5, proj=('cyl', proj))
+pplt.rc.reso = 'med'  # use higher res for zoomed in geographic features
+proj = pplt.Proj('cyl', lonlim=(-20, 180), latlim=(-10, 50), basemap=True)
+fig, axs = pplt.subplots(nrows=2, refwidth=5, proj=('cyl', proj))
 axs.format(
     land=True, labels=True, lonlines=20, latlines=20,
     gridminor=True, suptitle='Zooming into projections'
@@ -384,11 +384,11 @@ axs[0].format(
 axs[1].format(title='Basemap example')
 
 # %%
-import proplot as plot
+import proplot as pplt
 
 # Pole-centered map projections
-proj = plot.Proj('npaeqd', boundinglat=60, basemap=True)
-fig, axs = plot.subplots(ncols=2, refwidth=2.7, proj=('splaea', proj))
+proj = pplt.Proj('npaeqd', boundinglat=60, basemap=True)
+fig, axs = pplt.subplots(ncols=2, refwidth=2.7, proj=('splaea', proj))
 axs.format(
     land=True, latmax=80,  # no gridlines poleward of 80 degrees
     suptitle='Zooming into polar projections'
@@ -397,23 +397,23 @@ axs[0].format(boundinglat=-60, title='Cartopy example')
 axs[1].format(title='Basemap example')
 
 # %%
-import proplot as plot
+import proplot as pplt
 
 # Zooming in on continents
-proj1 = plot.Proj('lcc', lon_0=0)  # cartopy projection
-proj2 = plot.Proj('lcc', lon_0=-100, lat_0=45, width=8e6, height=8e6, basemap=True)
-fig, axs = plot.subplots(ncols=2, refwidth=3, proj=(proj1, proj2))
+proj1 = pplt.Proj('lcc', lon_0=0)  # cartopy projection
+proj2 = pplt.Proj('lcc', lon_0=-100, lat_0=45, width=8e6, height=8e6, basemap=True)
+fig, axs = pplt.subplots(ncols=2, refwidth=3, proj=(proj1, proj2))
 axs.format(suptitle='Zooming into specific regions', land=True)
 axs[0].format(lonlim=(-20, 50), latlim=(30, 70), title='Cartopy example')
 axs[1].format(lonlines=20, title='Basemap example')
 
 
 # %%
-import proplot as plot
+import proplot as pplt
 
 # Zooming to very small scale with degree-minute-second labels
-plot.rc.reso = 'hi'
-fig, axs = plot.subplots(ncols=2, refwidth=2.5, proj='cyl')
+pplt.rc.reso = 'hi'
+fig, axs = pplt.subplots(ncols=2, refwidth=2.5, proj='cyl')
 axs.format(
     land=True, labels=True,
     borders=True, borderscolor='white',
@@ -421,7 +421,7 @@ axs.format(
 )
 axs[0].format(lonlim=(-7.5, 2), latlim=(49.5, 59))
 axs[1].format(lonlim=(-6, -2), latlim=(54.5, 58.5))
-plot.rc.reset()
+pplt.rc.reset()
 
 # %% [raw] raw_mimetype="text/restructuredtext"
 # .. _proj_included:
@@ -443,7 +443,7 @@ plot.rc.reset()
 # and `~cartopy.crs.SouthPolarStereo` projections.
 
 # %%
-import proplot as plot
+import proplot as pplt
 
 # Table of cartopy projections
 projs = [
@@ -453,7 +453,7 @@ projs = [
     'npstere', 'nplaea', 'npaeqd', 'npgnom', 'igh',
     'eck1', 'eck2', 'eck3', 'eck4', 'eck5', 'eck6'
 ]
-fig, axs = plot.subplots(ncols=3, nrows=10, figwidth=7, proj=projs)
+fig, axs = pplt.subplots(ncols=3, nrows=10, figwidth=7, proj=projs)
 axs.format(
     land=True, reso='lo', labels=False,
     suptitle='Table of cartopy projections'
@@ -462,7 +462,7 @@ for proj, ax in zip(projs, axs):
     ax.format(title=proj, titleweight='bold', labels=False)
 
 # %%
-import proplot as plot
+import proplot as pplt
 
 # Table of basemap projections
 projs = [
@@ -472,7 +472,7 @@ projs = [
     'vandg', 'aea', 'eqdc', 'gnom', 'cass', 'lcc',
     'npstere', 'npaeqd', 'nplaea'
 ]
-fig, axs = plot.subplots(ncols=3, nrows=8, basemap=True, figwidth=7, proj=projs)
+fig, axs = pplt.subplots(ncols=3, nrows=8, basemap=True, figwidth=7, proj=projs)
 axs.format(
     land=True, labels=False,
     suptitle='Table of basemap projections'

--- a/docs/subplots.py
+++ b/docs/subplots.py
@@ -76,11 +76,11 @@
 #      avoid colorbars that look "too skinny" or "too fat".
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
 
 # Auto sized grid of cartopy projections
-fig, axs = plot.subplots(ncols=2, nrows=3, proj='robin')
+fig, axs = pplt.subplots(ncols=2, nrows=3, proj='robin')
 axs.format(
     land=True, landcolor='k',
     suptitle='Auto figure sizing with grid of cartopy projections'
@@ -88,7 +88,7 @@ axs.format(
 
 # Auto sized grid of images
 state = np.random.RandomState(51423)
-fig, axs = plot.subplots(ncols=3, nrows=2, refwidth=1.7)
+fig, axs = pplt.subplots(ncols=3, nrows=2, refwidth=1.7)
 colors = state.rand(15, 12, 3).cumsum(axis=2)
 colors /= colors.max()
 axs.imshow(colors)
@@ -97,12 +97,12 @@ axs.format(
 )
 
 # %%
-import proplot as plot
+import proplot as pplt
 
 # Change the reference subplot width
 suptitle = 'Effect of subplot width on figure size'
 for refwidth in ('4cm', '6cm'):
-    fig, axs = plot.subplots(ncols=2, refwidth=refwidth,)
+    fig, axs = pplt.subplots(ncols=2, refwidth=refwidth,)
     axs[0].format(
         suptitle=suptitle,
         title=f'refwidth = {refwidth}', titleweight='bold',
@@ -111,7 +111,7 @@ for refwidth in ('4cm', '6cm'):
 
 # Change the reference subplot aspect ratio
 for refaspect in (1, (3, 2)):
-    fig, axs = plot.subplots(ncols=2, nrows=2, refwidth=1.6, refaspect=refaspect)
+    fig, axs = pplt.subplots(ncols=2, nrows=2, refwidth=1.6, refaspect=refaspect)
     axs[0].format(
         suptitle='Effect of subplot aspect ratio on figure size',
         title=f'refaspect = {refaspect}', titleweight='bold',
@@ -119,11 +119,11 @@ for refaspect in (1, (3, 2)):
     )
 
 # %%
-import proplot as plot
+import proplot as pplt
 
 # Change the reference subplot in presence of unequal width/height ratios
 for ref in (1, 2):
-    fig, axs = plot.subplots(
+    fig, axs = pplt.subplots(
         ref=ref, nrows=3, ncols=3, wratios=(3, 2, 2),
         refwidth=1.1,
     )
@@ -135,7 +135,7 @@ for ref in (1, 2):
 
 # Change the reference subplot in a complex grid
 for ref in (1, 2):
-    fig, axs = plot.subplots(
+    fig, axs = pplt.subplots(
         [[1, 2], [1, 3]],
         ref=ref, refwidth=1.8, span=False
     )
@@ -178,10 +178,10 @@ for ref in (1, 2):
 # variable spacing between subplot rows and columns.
 
 # %%
-import proplot as plot
+import proplot as pplt
 
 # Automatic spacing for all margins and between all columns and rows
-fig, axs = plot.subplots(nrows=3, ncols=3, refwidth=1.1, share=0)
+fig, axs = pplt.subplots(nrows=3, ncols=3, refwidth=1.1, share=0)
 
 # Formatting that stress-tests the algorithm
 axs[1].format(xlabel='xlabel\nxlabel\nxlabel', ylabel='ylabel\nylabel\nylabel')
@@ -193,10 +193,10 @@ axs.format(
 )
 
 # %%
-import proplot as plot
+import proplot as pplt
 
 # Manual spacing for certain margins and between certain columns and rows
-fig, axs = plot.subplots(
+fig, axs = pplt.subplots(
     ncols=4, nrows=3, refwidth=1.1, span=False,
     bottom='5em', right='5em',  # margin spacing overrides
     wspace=(0, 0, None), hspace=(0, None),  # column and row spacing overrides
@@ -249,12 +249,12 @@ axs[:, 0].format(ylabel='ylabel\nylabel')
 # on the appearance of simple subplot grids.
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
 N = 50
 M = 40
 state = np.random.RandomState(51423)
-colors = plot.Colors('grays_r', M, left=0.1, right=0.8)
+colors = pplt.Colors('grays_r', M, left=0.1, right=0.8)
 datas = []
 for scale in (1, 3, 7, 0.2):
     data = scale * (state.rand(N, M) - 0.5).cumsum(axis=0)[N // 2:, :]
@@ -262,7 +262,7 @@ for scale in (1, 3, 7, 0.2):
 
 # Same plot with different sharing and spanning settings
 for share in (0, 1, 2, 3):
-    fig, axs = plot.subplots(
+    fig, axs = pplt.subplots(
         ncols=4, refaspect=1, refwidth=1.06,
         sharey=share, spanx=share // 2
     )
@@ -275,16 +275,16 @@ for share in (0, 1, 2, 3):
         )
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
-plot.rc.reset()
-plot.rc.cycle = 'Set3'
+pplt.rc.reset()
+pplt.rc.cycle = 'Set3'
 state = np.random.RandomState(51423)
 titles = ['With redundant labels', 'Without redundant labels']
 
 # Same plot with and without default sharing settings
 for mode in (0, 1):
-    fig, axs = plot.subplots(
+    fig, axs = pplt.subplots(
         nrows=4, ncols=4, share=3 * mode,
         span=1 * mode, refwidth=1
     )
@@ -336,8 +336,8 @@ for mode in (0, 1):
 #     for details on wrapper functions.
 
 # %%
-import proplot as plot
-fig, axs = plot.subplots(nrows=8, ncols=8, refwidth=0.7, space=0)
+import proplot as pplt
+fig, axs = pplt.subplots(nrows=8, ncols=8, refwidth=0.7, space=0)
 axs.format(
     abc=True, abcloc='ur',
     xlabel='x axis', ylabel='y axis', xticks=[], yticks=[],
@@ -346,8 +346,8 @@ axs.format(
 
 
 # %%
-import proplot as plot
-fig, axs = plot.subplots(ncols=3, nrows=3, space=0, refwidth='10em')
+import proplot as pplt
+fig, axs = pplt.subplots(ncols=3, nrows=3, space=0, refwidth='10em')
 axs.format(
     abc=True, abcloc='ul', abcstyle='A.',
     xticks='null', yticks='null', facecolor='gray5',
@@ -381,14 +381,14 @@ axs[-3:].format(abcbbox=True)  # also disables abcborder
 # and `points <https://en.wikipedia.org/wiki/Point_(typography)>`__.
 
 # %%
-import proplot as plot
+import proplot as pplt
 import numpy as np
-with plot.rc.context(fontsize='12px'):
-    fig, axs = plot.subplots(
+with pplt.rc.context(fontsize='12px'):
+    fig, axs = pplt.subplots(
         ncols=3, figwidth='15cm', figheight='3in',
         wspace=('10pt', '20pt'), right='10mm'
     )
-    cmap = plot.Colormap('Mono')
+    cmap = pplt.Colormap('Mono')
     cb = fig.colorbar(
         cmap, loc='b', extend='both', label='colorbar',
         width='2em', extendsize='3em', shrink=0.8,

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -53,7 +53,7 @@ We recommend importing ProPlot as follows:
 
 .. code-block:: python
 
-   import proplot as plot
+   import proplot as pplt
 
 This differentiates ProPlot from the usual ``plt`` abbreviation reserved for
 the `~matplotlib.pyplot` module. The abbreviation ``pplt`` is a popular
@@ -69,7 +69,7 @@ Creating plots with ProPlot always begins with a call to the
 
 .. code-block:: python
 
-   fig, axs = plot.subplots(...)
+   fig, axs = pplt.subplots(...)
 
 The `~proplot.ui.subplots` command is modeled after
 matplotlib's native `matplotlib.pyplot.subplots` command

--- a/docs/why.rst
+++ b/docs/why.rst
@@ -105,8 +105,8 @@ highly customized figures. As an example, it is trivial to see that...
 
 .. code-block:: python
 
-   import proplot as plot
-   fig, axs = plot.subplots(ncols=2)
+   import proplot as pplt
+   fig, axs = pplt.subplots(ncols=2)
    axs.format(linewidth=1, color='gray')
    axs.format(xlim=(0, 100), xticks=10, xtickminor=True, xlabel='foo', ylabel='bar')
 
@@ -500,7 +500,7 @@ longitude-latitude (i.e., "Plate Carrée") coordinates.
 
 ProPlot lets you specify geographic projections by simply passing
 the `PROJ <https://proj.org>`__ name to `~proplot.ui.subplots` with
-e.g. ``fig, ax = plot.subplots(proj='pcarree')``. Alternatively, the
+e.g. ``fig, ax = pplt.subplots(proj='pcarree')``. Alternatively, the
 `~proplot.constructor.Proj` constructor function can be used to quickly generate
 `cartopy.crs.Projection` and `~mpl_toolkits.basemap.Basemap` instances.
 
@@ -712,8 +712,8 @@ than globally.
 In ProPlot, you can use the `~proplot.config.rc` object to change lots of
 settings at once with convenient shorthands.  This is meant to replace
 matplotlib's `~matplotlib.rcParams` dictionary. Settings can be changed
-with ``plot.rc.key = value``, ``plot.rc[key] = value``,
-``plot.rc.update(...)``, with the `~proplot.axes.Axes.format` method, or with
+with ``pplt.rc.key = value``, ``pplt.rc[key] = value``,
+``pplt.rc.update(...)``, with the `~proplot.axes.Axes.format` method, or with
 the `~proplot.config.RcConfigurator.context` method. ProPlot also adds a bunch
 of new settings for controlling proplot-specific features.
 See the :ref:`user guide <ug_config>` for details.

--- a/proplot/axes/base.py
+++ b/proplot/axes/base.py
@@ -1114,7 +1114,7 @@ class Axes(maxes.Axes):
         from .cartesian import CartesianAxes
         if not isinstance(self, CartesianAxes):
             warnings._warn_proplot(
-                'Cannot adjust aspect ratio or ticks for non-Cartesian heatmap plot. '
+                'Cannot adjust aspect ratio or ticks for non-Cartesian heatmap pplt. '
                 'Consider using pcolormesh() or pcolor() instead.'
             )
         else:

--- a/proplot/axes/geo.py
+++ b/proplot/axes/geo.py
@@ -1367,7 +1367,7 @@ class BasemapAxes(GeoAxes):
                 f'Got lonlim={lonlim!r}, latlim={latlim!r}, '
                 f'boundinglat={boundinglat!r}, but you cannot "zoom into" a '
                 'basemap projection after creating it. Add any of the following '
-                "keyword args in your call to plot.Proj('name', basemap=True, ...): "
+                "keyword args in your call to pplt.Proj('name', basemap=True, ...): "
                 "'boundinglat', 'llcrnrlon', 'llcrnrlat', "
                 "'urcrnrlon', 'urcrnrlat', 'llcrnrx', 'llcrnry', "
                 "'urcrnrx', 'urcrnry', 'width', or 'height'."

--- a/proplot/axes/plot.py
+++ b/proplot/axes/plot.py
@@ -1720,7 +1720,7 @@ def _stem_extras(
 
 def _check_negpos(name, **kwargs):
     """
-    Issue warnings if we are ignoring arguments for "negpos" plot.
+    Issue warnings if we are ignoring arguments for "negpos" pplt.
     """
     for key, arg in kwargs.items():
         if arg is None:
@@ -2861,7 +2861,7 @@ def _auto_levels_locator(
     nozero : bool, optional
         Whether zero should be excluded from automatic levels. This is also
         implemented in `apply_cmap` so that `nozero` can be used to remove user
-        input levels (e.g. ``ax.contour(..., levels=plot.arange(-5, 5), nozero=True)``),
+        input levels (e.g. ``ax.contour(..., levels=pplt.arange(-5, 5), nozero=True)``),
         but is replecated here so power users can use this function in isolation.
 
     Returns
@@ -3462,7 +3462,7 @@ def apply_cmap(
         elif pcolor:
             _labels_pcolor(self, obj, fmt=fmt, **labels_kw)
         else:
-            raise RuntimeError(f'Not possible to add labels to {name!r} plot.')
+            raise RuntimeError(f'Not possible to add labels to {name!r} pplt.')
 
     # Optionally add colorbar
     if colorbar:

--- a/proplot/axes/polar.py
+++ b/proplot/axes/polar.py
@@ -72,12 +72,12 @@ class PolarAxes(base.Axes, mproj.PolarAxes):
             and anticlockwise corresponds to ``1``. Default is ``1``.
         thetamin, thetamax : float, optional
             The lower and upper azimuthal bounds in degrees. If
-            ``thetamax != thetamin + 360``, this produces a sector plot.
+            ``thetamax != thetamin + 360``, this produces a sector pplt.
         thetalim : (float, float), optional
             Specifies `thetamin` and `thetamax` at once.
         rmin, rmax : float, optional
             The inner and outer radial limits. If ``r0 != rmin``, this
-            produces an annular plot.
+            produces an annular pplt.
         rlim : (float, float), optional
             Specifies `rmin` and `rmax` at once.
         rborder : bool, optional

--- a/proplot/colors.py
+++ b/proplot/colors.py
@@ -3,7 +3,7 @@
 New colormap classes and colormap normalization classes.
 """
 # NOTE: Avoid colormap/color name conflicts by checking
-# set(plot.colors._cmap_database) & set(plot.colors.mcolors._colors_full_map)
+# set(pplt.colors._cmap_database) & set(pplt.colors.mcolors._colors_full_map)
 # whenever new default colormaps are added. Currently result is
 # {'gray', 'marine', 'ocean', 'pink'} which correspond to MATLAB and GNUplot maps.
 import json
@@ -1595,13 +1595,13 @@ class PerceptuallyUniformColormap(LinearSegmentedColormap, _Colormap):
         `segmentdata` dictionary that uses color names for the hue data,
         instead of channel values between ``0`` and ``360``.
 
-        >>> import proplot as plot
+        >>> import proplot as pplt
         >>> data = {
         >>>     'h': [[0, 'red', 'red'], [1, 'blue', 'blue']],
         >>>     's': [[0, 100, 100], [1, 100, 100]],
         >>>     'l': [[0, 100, 100], [1, 20, 20]],
         >>> }
-        >>> cmap = plot.PerceptuallyUniformColormap(data)
+        >>> cmap = pplt.PerceptuallyUniformColormap(data)
 
         See also
         --------
@@ -2244,11 +2244,11 @@ class LinearSegmentedNorm(mcolors.Normalize):
         `~matplotlib.axes.Axes.contourf`, resulting in the automatic
         application of `LinearSegmentedNorm`.
 
-        >>> import proplot as plot
+        >>> import proplot as pplt
         >>> import numpy as np
         >>> levels = [1, 2, 5, 10, 20, 50, 100, 200, 500, 1000]
         >>> data = 10 ** (3 * np.random.rand(10, 10))
-        >>> fig, ax = plot.subplots()
+        >>> fig, ax = pplt.subplots()
         >>> ax.contourf(data, levels=levels)
         """
         levels = np.asarray(levels)

--- a/proplot/config.py
+++ b/proplot/config.py
@@ -716,16 +716,16 @@ class RcConfigurator(object):
         The below applies settings to axes in a specific figure using
         `~RcConfigurator.context`.
 
-        >>> import proplot as plot
-        >>> with plot.rc.context(linewidth=2, ticklen=5):
-        >>>     fig, ax = plot.subplots()
+        >>> import proplot as pplt
+        >>> with pplt.rc.context(linewidth=2, ticklen=5):
+        >>>     fig, ax = pplt.subplots()
         >>>     ax.plot(data)
 
         The below applies settings to a specific axes using `~proplot.axes.Axes.format`,
         which uses `~RcConfigurator.context` internally.
 
-        >>> import proplot as plot
-        >>> fig, ax = plot.subplots()
+        >>> import proplot as pplt
+        >>> fig, ax = pplt.subplots()
         >>> ax.format(linewidth=2, ticklen=5)
         """
         # Add input dictionaries

--- a/proplot/figure.py
+++ b/proplot/figure.py
@@ -143,7 +143,7 @@ class Figure(mfigure.Figure):
     # NOTE: If _rename_kwargs argument is an invalid identifier, it is
     # simply used in the warning message.
     @warnings._rename_kwargs('0.7', pad='outerpad', axpad='innerpad')
-    @warnings._rename_kwargs('0.6.4', autoformat='plot.rc.autoformat = {}')
+    @warnings._rename_kwargs('0.6.4', autoformat='pplt.rc.autoformat = {}')
     def __init__(
         self, tight=None,
         ref=1, outerpad=None, innerpad=None, panelpad=None, includepanels=False,
@@ -241,7 +241,7 @@ class Figure(mfigure.Figure):
                 f'Ignoring tight_layout={tight_layout} and '
                 f'contrained_layout={constrained_layout}. ProPlot uses its '
                 'own tight layout algorithm, activated by default or with '
-                'plot.subplots(tight=True).'
+                'pplt.subplots(tight=True).'
             )
         self._authorized_add_subplot = False
         self._is_preprocessing = False

--- a/proplot/scale.py
+++ b/proplot/scale.py
@@ -770,11 +770,11 @@ class CutoffScale(_Scale, mscale.ScaleBase):
 
         Example
         -------
-        >>> import proplot as plot
+        >>> import proplot as pplt
         >>> import numpy as np
-        >>> scale = plot.CutoffScale(10, 0.5)  # move slower above 10
-        >>> scale = plot.CutoffScale(10, 2, 20)  # zoom out between 10 and 20
-        >>> scale = plot.CutoffScale(10, np.inf, 20)  # jump from 10 to 20
+        >>> scale = pplt.CutoffScale(10, 0.5)  # move slower above 10
+        >>> scale = pplt.CutoffScale(10, 2, 20)  # zoom out between 10 and 20
+        >>> scale = pplt.CutoffScale(10, np.inf, 20)  # jump from 10 to 20
         """
         # NOTE: See https://stackoverflow.com/a/5669301/4970632
         super().__init__()

--- a/proplot/tests/test_journals.py
+++ b/proplot/tests/test_journals.py
@@ -1,6 +1,6 @@
 import pytest
 
-import proplot as plot
+import proplot as pplt
 from proplot.subplots import JOURNAL_SPECS
 
 
@@ -8,4 +8,4 @@ from proplot.subplots import JOURNAL_SPECS
 @pytest.mark.parametrize('journal', JOURNAL_SPECS.keys())
 def test_journal_subplots(journal):
     """Tests that subplots can be generated with journal specifications."""
-    f, axs = plot.subplots(journal=journal)
+    f, axs = pplt.subplots(journal=journal)

--- a/proplot/ticker.py
+++ b/proplot/ticker.py
@@ -330,7 +330,7 @@ class AutoFormatter(mticker.ScalarFormatter):
         # only meant to be used for linear scales and cannot handle the wide
         # range of magnitudes in e.g. log scales. To correct this, we only
         # truncate if value is within `offset` order of magnitude of the float
-        # precision. Common issue is e.g. levels=plot.arange(-1, 1, 0.1).
+        # precision. Common issue is e.g. levels=pplt.arange(-1, 1, 0.1).
         # This choice satisfies even 1000 additions of 0.1 to -100.
         match = REGEX_ZERO.match(string)
         decimal_point = self._get_decimal_point()

--- a/proplot/ui.py
+++ b/proplot/ui.py
@@ -334,12 +334,12 @@ or dict thereof, optional
         two options:
 
         * Pass a *list* of projection specifications, one for each subplot.
-          For example, ``plot.subplots(ncols=2, proj=('cartesian', 'robin'))``.
+          For example, ``pplt.subplots(ncols=2, proj=('cartesian', 'robin'))``.
         * Pass a *dictionary* of projection specifications, where the
           keys are integers or tuples of integers that indicate the projection
           to use for the corresponding subplot(s). If a key is not provided, the
           default projection ``'cartesian'`` is used. For example,
-          ``plot.subplots(ncols=4, proj={2: 'merc', (3, 4): 'stere'})`` creates
+          ``pplt.subplots(ncols=4, proj={2: 'merc', (3, 4): 'stere'})`` creates
           a figure with a Cartesian axes for the first subplot, a Mercator
           projection for the second subplot, and a Stereographic projection
           for the third and fourth subplots.
@@ -349,7 +349,7 @@ or dict thereof, optional
         `~cartopy.crs.Projection` classes on instantiation. If dictionary of
         properties, applies globally. If list of dictionaries or dictionary of
         dictionaries, these apply to specific subplots, as with `proj`. For example,
-        ``plot.subplots(ncols=2, proj_kw={1: {'lon_0': 0}, 2: {'lon_0': 180}})``
+        ``pplt.subplots(ncols=2, proj_kw={1: {'lon_0': 0}, 2: {'lon_0': 180}})``
         centers the projection in the left subplot on the prime meridian and
         in the right subplot on the international dateline.
     basemap : bool, list of bool, or dict of bool, optional
@@ -669,8 +669,8 @@ class SubplotsContainer(list):
 
         Example
         -------
-        >>> import proplot as plot
-        >>> fig, axs = plot.subplots(nrows=3, ncols=3, colorbars='b', bstack=2)
+        >>> import proplot as pplt
+        >>> fig, axs = pplt.subplots(nrows=3, ncols=3, colorbars='b', bstack=2)
         >>> axs[0]  # the subplot in the top-right corner
         >>> axs[3]  # the first subplot in the second row
         >>> axs[1,2]  # the subplot in the second row, third from the left
@@ -754,8 +754,8 @@ class SubplotsContainer(list):
 
         Example
         -------
-        >>> import proplot as plot
-        >>> fig, axs = plot.subplots(nrows=2, ncols=2)
+        >>> import proplot as pplt
+        >>> fig, axs = pplt.subplots(nrows=2, ncols=2)
         >>> axs.format(...)  # calls "format" on all subplots
         >>> panels = axs.panel_axes('right')  # returns SubplotsContainer of panels
         >>> panels.format(...)  # calls "format" on all panels

--- a/proplot/utils.py
+++ b/proplot/utils.py
@@ -86,7 +86,7 @@ color : str
 def arange(min_, *args):
     """
     Identical to `numpy.arange` but with inclusive endpoints. For
-    example, ``plot.arange(2, 4)`` returns ``np.array([2, 3, 4])`` instead
+    example, ``pplt.arange(2, 4)`` returns ``np.array([2, 3, 4])`` instead
     of ``np.array([2, 3])``. This command is useful for generating lists of
     tick locations or colorbar level boundaries.
 


### PR DESCRIPTION
Resolves #139. This switches the recommended import statement from `import proplot as plot` to `import prolot as pplt` throughout the documentation and examples, in agreement with the poll winner.