### PR TITLE
 adding custom abc and multiple titles #294

### DIFF
--- a/WHATSNEW.rst
+++ b/WHATSNEW.rst
@@ -63,7 +63,7 @@ Style changes
 
 Features
 --------
-
+* Adding custom abc and titles (:pr:`#294`) by `Pratiman Patel`.
 * Significantly improve "tight layout" performance in geographic plots by skipping
   artists with clipping paths/boxes set to the subplot bounds (:commit:`f891e4f0`).
 * Add modifiable `proplot.figure.Figure.tight` property to retrieve/change the

--- a/WHATSNEW.rst
+++ b/WHATSNEW.rst
@@ -63,7 +63,7 @@ Style changes
 
 Features
 --------
-* Adding custom abc and titles (:pr:`#294`) by `Pratiman Patel`.
+* Adding custom abc and titles (:pr:`294`) by `Pratiman Patel`.
 * Significantly improve "tight layout" performance in geographic plots by skipping
   artists with clipping paths/boxes set to the subplot bounds (:commit:`f891e4f0`).
 * Add modifiable `proplot.figure.Figure.tight` property to retrieve/change the

--- a/proplot/axes/base.py
+++ b/proplot/axes/base.py
@@ -298,7 +298,7 @@ docstring._snippet_manager['axes.panel'] = _panel_docstring
 _axes_format_docstring = """
 title : str, optional
     The axes title.
-abc : bool or str, default: :rc:`abc`
+abc : bool or str or tuple, default: :rc:`abc`
     The "a-b-c" subplot label style. Must contain the character ``a`` or ``A``,
     for example ``'a.'``, or ``'A'``. If ``True`` then the default style of
     ``'a'`` is used. The ``a`` or ``A`` is replaced with the alphabetic character
@@ -345,10 +345,10 @@ abctitlepad : float, default: :rc:`abc.titlepad`
     The horizontal padding between a-b-c labels and titles in the same location.
     %(units.pt)s
 ltitle, ctitle, rtitle, ultitle, uctitle, urtitle, lltitle, lctitle, lrtitle \
-: str, optional
+: str, tuple, optional
     Shorthands for the below keywords.
 lefttitle, centertitle, righttitle, upperlefttitle, uppercentertitle, upperrighttitle, \
-lowerlefttitle, lowercentertitle, lowerrighttitle : str, optional
+lowerlefttitle, lowercentertitle, lowerrighttitle : str, tuple, optional
     Additional titles in specific positions. This works as an alternative
     to the ``ax.format(title='Title', titleloc=loc)`` workflow and permits
     adding more than one title-like label for a single axes.
@@ -2450,9 +2450,11 @@ class Axes(maxes.Axes):
         abc = rc.find('abc', context=True)  # 1st run, or changed
         if abc is True:
             abc = 'a'
-        if abc and (not isinstance(abc, str) or 'a' not in abc and 'A' not in abc):
-            raise ValueError(f'Invalid style {abc!r}. Must include letter "a" or "A".')
-        if abc and self.number is not None:
+        if isinstance(abc, tuple):
+            kw['text'] = abc[self.number - 1]
+        elif abc and (not isinstance(abc, str) or 'a' not in abc and 'A' not in abc):
+            raise ValueError(f'Invalid style {abc!r}. Must include letter "a" or "A"')
+        if isinstance(abc, str) and self.number is not None:
             nabc, iabc = divmod(self.number - 1, 26)
             old = re.search('[aA]', abc).group()  # return the *first* 'a' or 'A'
             new = (nabc + 1) * ABC_STRING[iabc]
@@ -2531,7 +2533,9 @@ class Axes(maxes.Axes):
         # necesssary. For inner panels, use the border and bbox settings.
         if loc not in ('left', 'right', 'center'):
             kw.update(self._title_border_kwargs)
-        if title is not None:
+        if isinstance(title, tuple):
+            kw['text'] = title[self.number - 1]
+        elif title is not None:
             kw['text'] = title
         kw.update(kwargs)
         self._title_dict[loc].update(kw)

--- a/proplot/internals/rcsetup.py
+++ b/proplot/internals/rcsetup.py
@@ -181,12 +181,15 @@ def _validate_abc(value):
     Validate a-b-c setting.
     """
     try:
-        return _validate_bool(value)
+        if type(value) is not tuple:
+            return _validate_bool(value)
     except ValueError:
         pass
     if isinstance(value, str) and 'a' in value.lower():
         return value
-    raise ValueError("A-b-c specification must be string containing 'a' or 'A'.")
+    if isinstance(value, tuple):
+        return value
+    raise ValueError("A-b-c specification must be string containing 'a' or 'A'")
 
 
 def _validate_belongs(*options):


### PR DESCRIPTION
## Description

Currently, `abc` does not consider the custom text. A provision can be made to incorporate that. Multiple titles can be incorporated in the `format`. I know there are ways that the functions may not be even needed. However, it is for the sake of consistency and making the user end code simple.

### Modified Code for `abc`
```python
import proplot as pplt
fig = pplt.figure(space=0, refwidth='10em')
axs = fig.subplots(nrows=3, ncols=2)
axs.format(
    abc=('A','B','1','2','a','b'), abcloc='ul',
    xticks='null', yticks='null', facecolor='gray5',
    xlabel='x axis', ylabel='y axis',
)
```

### Output
![abc_title](https://user-images.githubusercontent.com/31694629/147872489-40ea48af-b3d6-48b3-8e74-1e8e0bfc927e.png)

### Modified Code `title`
```python
import proplot as pplt
fig = pplt.figure(space=0, refwidth='10em')
axs = fig.subplots(nrows=3, ncols=2)
axs.format(
    urtitle=('Title 1', 'Title 2', 'Test 1', 'Test2', 'Exp1', 'Exp2'),
    xticks='null', yticks='null', facecolor='gray5',
    xlabel='x axis', ylabel='y axis',
)
```

### Output
![muliple_titles](https://user-images.githubusercontent.com/31694629/147872519-ddac0a5c-57a5-4322-bb3a-9999a0a86230.png)

