### PR TITLE
Specify maximum matplotlib dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,6 @@ project_urls =
 [options]
 packages = proplot
 setup_requires = setuptools>=44; toml; setuptools_scm>=3.4.3
-install_requires = matplotlib>=3.0.0,<3.5.0
+install_requires = matplotlib>=3.0.0,<3.6.0
 include_package_data = True
 python_requires = >=3.6.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,6 @@ project_urls =
 [options]
 packages = proplot
 setup_requires = setuptools>=44; toml; setuptools_scm>=3.4.3
-install_requires = matplotlib>=3.0.0
+install_requires = matplotlib>=3.0.0,<3.5.0
 include_package_data = True
 python_requires = >=3.6.0


### PR DESCRIPTION
Why not do a point release with just this fix, so at least ProPlot is useable by `pip install`ers until you get a fix out?